### PR TITLE
falter-policyrouting: use $IPKG_INSTROOT in init files

### DIFF
--- a/packages/falter-policyrouting/files/etc/init.d/freifunk-policyrouting
+++ b/packages/falter-policyrouting/files/etc/init.d/freifunk-policyrouting
@@ -1,8 +1,8 @@
 #!/bin/sh /etc/rc.common
 
 START=15
-. /lib/functions/network.sh
-. /lib/functions.sh
+. $IPKG_INSTROOT/lib/functions/network.sh
+. $IPKG_INSTROOT/lib/functions.sh
 
 proto="4"
 #[ -f /proc/net/ipv6_route ] && proto="4 6"


### PR DESCRIPTION
The following warning is printed when generating images

```/lib/functions.sh: No such file or directory```

which can be fixed by changing the include to

```$IPKG_INSTROOT/lib/functions.sh```

fixes #3

Signed-off-by: pmelange <isprotejesvalkata@gmail.com>