### PR TITLE
luci-app-ffwizard-falter: fix 5 GHz adhoc mesh configuration

### DIFF
--- a/packages/falter-common/files-common/etc/config/freifunk
+++ b/packages/falter-common/files-common/etc/config/freifunk
@@ -104,6 +104,12 @@ config 'defaults' 'wifi_iface'
 	option 'bssid' '12:CA:FF:EE:BA:BE'
 	option 'mcast_rate' '6000'
 
+config 'defaults' 'wifi_iface_5'
+	option 'mode' 'adhoc'
+	option 'encryption' 'none'
+	option 'bssid' '02:36:CA:FF:EE:EE'
+	option 'mcast_rate' '6000'
+
 config 'defaults' 'interface'
 	option 'netmask' '255.255.0.0'
 	option 'dns' '8.8.8.8 212.204.49.83 141.1.1.1'


### PR DESCRIPTION
The wizard crashed if you tried to configure a 5GHz adhoc mesh.
Fixes #9.