### PR TITLE
falter-berlin-network-defaults: add no-internet-ssid-changer

### DIFF
--- a/packages/falter-berlin-network-defaults/Makefile
+++ b/packages/falter-berlin-network-defaults/Makefile
@@ -39,6 +39,8 @@ define Package/falter-berlin-network-defaults/install
 	$(CP) ./pingcheck/online.d/* $(1)/etc/pingcheck/online.d/
 	$(INSTALL_DIR) $(1)/etc/pingcheck/offline.d
 	$(CP) ./pingcheck/offline.d/* $(1)/etc/pingcheck/offline.d/
+	$(INSTALL_DIR) $(1)/etc/pingcheck/panic.d
+	$(CP) ./pingcheck/panic.d/* $(1)/etc/pingcheck/panic.d/
 endef
 
 $(eval $(call BuildPackage,falter-berlin-network-defaults))

--- a/packages/falter-berlin-network-defaults/pingcheck/online.d/70-freifunk-online-ssid
+++ b/packages/falter-berlin-network-defaults/pingcheck/online.d/70-freifunk-online-ssid
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+[ "$GLOBAL" = ONLINE ] || exit
+
+# check if no internet ssids exist
+[ $(uci show wireless | grep -o 'no-internet.freifunk.net' | wc -l) -gt 0 ] || exit
+
+# iterate over dhcp sections and change ssid
+for i in `uci show wireless | grep "dhcp-" | grep -o "wireless.@wifi-iface\[\d\]"` ; do
+  uci set $i.ssid=$(uci get freifunk.community.ssid)
+done
+
+# commit to config files
+uci commit
+
+# apply to wifi
+wifi reconf

--- a/packages/falter-berlin-network-defaults/pingcheck/panic.d/70-freifunk-offline-ssid
+++ b/packages/falter-berlin-network-defaults/pingcheck/panic.d/70-freifunk-offline-ssid
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+# panic.d does not get GLOBAL, but offline.d gets it
+# [ "$GLOBAL" = OFFLINE ] || exit
+
+# iterate over dhcp sections
+for i in `uci show wireless | grep "dhcp-" | grep -o "wireless.@wifi-iface\[\d\]"` ; do
+  uci set $i.ssid='no-internet.freifunk.net'
+done
+
+# commit to config files
+uci commit
+
+# apply to wifi
+wifi reconf

--- a/packages/falter-berlin-network-defaults/uci-defaults/freifunk-berlin-pingcheck-defaults
+++ b/packages/falter-berlin-network-defaults/uci-defaults/freifunk-berlin-pingcheck-defaults
@@ -11,5 +11,7 @@ uci set pingcheck.@default\[0\].host=livecheck.berlin.freifunk.net
 # set the default timeout to 60 seconds
 uci set pingcheck.@default\[0\].timeout=60
 
-uci commit pingcheck
+# activate panic.d scripts
+uci set pingcheck.@default\[0\].panic='1'
 
+uci commit pingcheck


### PR DESCRIPTION
Activate panic.d scripts and set the timer to 1 minute. If the node is not connected to the internet longer for 1 minute the ssid will change to 'no-internet.berlin.freifunk.net'.

If the node is back online the ssid will change automatically back to 'berlin.freifunk.net'.

Requested by #4.