### PR TITLE
falter-berlin-network-defaults: remove dependency to iwinfo

### DIFF
--- a/packages/falter-berlin-network-defaults/Makefile
+++ b/packages/falter-berlin-network-defaults/Makefile
@@ -1,7 +1,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=falter-berlin-network-defaults
-PKG_VERSION:=1
+PKG_VERSION:=2
 
 include $(INCLUDE_DIR)/package.mk
 
@@ -10,7 +10,7 @@ define Package/falter-berlin-network-defaults
   CATEGORY:=falter-berlin
   TITLE:=Freifunk Berlin network default configuration
   URL:=http://github.com/Freifunk-Spalter/packages
-  EXTRA_DEPENDS:=falter-berlin-lib-guard, iwinfo, pingcheck
+  EXTRA_DEPENDS:=falter-berlin-lib-guard, pingcheck
   PKGARCH:=all
 endef
 

--- a/packages/falter-berlin-network-defaults/uci-defaults/freifunk-berlin-correct-nsm2-txpower
+++ b/packages/falter-berlin-network-defaults/uci-defaults/freifunk-berlin-correct-nsm2-txpower
@@ -4,6 +4,7 @@
 # see https://github.com/freifunk-berlin/firmware/issues/381
 #
 
+[ ! $(which iwinfo) ] && exit 0
 iwinfo|grep -q 'NanoStation M2\|NanoStation Loco M2' || exit 0
 
 . /lib/functions/guard.sh


### PR DESCRIPTION
On devices which do not have wireless, installation of this package
failes because of the missing dependency.  To make this package not
depend on iwinfo, a check to see if it is installed is added to the
beginning of the correct-nsm2-txpower script.

fixes: #17
Signed-off-by: pmelange <isprotejesvalkata@gmail.com>