### PR TITLE
falter-berlin-network-defaults: use "command -v" instead of "which"

### DIFF
--- a/packages/falter-berlin-network-defaults/uci-defaults/freifunk-berlin-correct-nsm2-txpower
+++ b/packages/falter-berlin-network-defaults/uci-defaults/freifunk-berlin-correct-nsm2-txpower
@@ -4,7 +4,7 @@
 # see https://github.com/freifunk-berlin/firmware/issues/381
 #
 
-[ ! $(which iwinfo) ] && exit 0
+[ ! $(command -v iwinfo) ] && exit 0
 iwinfo|grep -q 'NanoStation M2\|NanoStation Loco M2' || exit 0
 
 . /lib/functions/guard.sh


### PR DESCRIPTION
As of upstream commit 1fdf6b745cc3d85be3743837817a360121554134 the
"which" command is not longer being used and instead "command -v",
which itself is POSIX compliant, is being used treewide.  In addition
there are plans to remove the "which" command to save a bit of space.

Signed-off-by: pmelange <isprotejesvalkata@gmail.com>