### PR TITLE
falter-berlin-fix-luci: add package falter-berlin-fix-luci

### DIFF
--- a/packages/falter-berlin-fix-luci/Makefile
+++ b/packages/falter-berlin-fix-luci/Makefile
@@ -1,0 +1,35 @@
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=falter-berlin-fix-luci
+PKG_VERSION:=1
+
+include $(INCLUDE_DIR)/package.mk
+
+define Package/falter-berlin-fix-luci
+  SECTION:=falter-berlin
+  CATEGORY:=falter-berlin
+  TITLE:=Freifunk Berlin fix-luci
+  URL:=http://github.com/Freifunk-Spalter/packages
+  PKGARCH:=all
+endef
+
+define Package/falter-berlin-fix-luci/description
+  Freifunk Berlin uci-defaults-script for fixing luci-button-not-shown-bug.
+endef
+
+define Build/Prepare
+	mkdir -p $(PKG_BUILD_DIR)
+endef
+
+define Build/Configure
+endef
+
+define Build/Compile
+endef
+
+define Package/falter-berlin-fix-luci/install
+	$(INSTALL_DIR) $(1)/etc/uci-defaults
+	$(CP) ./files/* $(1)/etc/uci-defaults
+endef
+
+$(eval $(call BuildPackage,falter-berlin-fix-luci))

--- a/packages/falter-berlin-fix-luci/README.md
+++ b/packages/falter-berlin-fix-luci/README.md
@@ -1,0 +1,6 @@
+# Falter-Fix-LuCI-Buttons
+
+This package is supposed to be used only for Falter-firmwares based on OpenWrt
+19.07.x. It fixes missing buttons on LuCi startup page by applying the
+workaround mentioned [here](https://github.com/Freifunk-Spalter/packages/issues/28#issuecomment-688809505).
+This is realised via a uci-default sctipt.

--- a/packages/falter-berlin-fix-luci/files/999-fix_luci_buttons.sh
+++ b/packages/falter-berlin-fix-luci/files/999-fix_luci_buttons.sh
@@ -1,0 +1,22 @@
+#! /bin/sh
+
+set -e
+
+. /usr/share/libubox/jshn.sh
+
+TMP_FILE="/tmp/tmp.json"
+SOURCE_FILE="/usr/share/luci/menu.d/luci-base.json"
+# delete "methods": [ "cookie:sysauth" ]
+sed -En '/"admin\/menu"/q;p' $SOURCE_FILE > $TMP_FILE && sed -En '/"admin\/menu"/,/END/p' $SOURCE_FILE | sed -En '/\W*"methods"/!p' >> $TMP_FILE
+cp $TMP_FILE $SOURCE_FILE
+#json_init
+#json_load_file /usr/share/luci/menu.d/luci-base.json
+#json_select "admin/menu"
+#json_add_object "auth"
+#json_close_object
+#json_dump -i > /usr/share/luci/menu.d/luci-base.json
+
+# replace html-stuff in /usr/lib/lua/luci/view/themes/bootstrap/footer.htm
+sed -ni '1h;1!H;${;g;s/<% if luci.dispatcher.context.authsession then %>.*\n\W*<script type="text\/javascript">L.require(.menu-bootstrap.)<.script>\n\W*<% end %>/<script type="text\/javascript">L\.require('"'menu-bootstrap'"')<\/script>/g;p;}' /usr/lib/lua/luci/view/themes/bootstrap/footer.htm
+
+exit 0


### PR DESCRIPTION
This package provides a uci-defaults-script, providing a workaround for the
buttons-not-shown-bug. Have a look at
https://github.com/Freifunk-Spalter/packages/issues/28#issuecomment-688809505
for more details.

Signed-off-by: Martin Hübner <martin.hubner@web.de>