### PR TITLE
luci-app-ffwizard-falter: No longer ask for passwords unnecessarilly

### DIFF
--- a/luci/luci-app-ffwizard-falter/Makefile
+++ b/luci/luci-app-ffwizard-falter/Makefile
@@ -2,7 +2,7 @@ include $(TOPDIR)/rules.mk
 
 LUCI_TITLE:=Freifunk Berlin configuration wizard
 LUCI_EXTRA_DEPENDS:=luci-compat, luci-mod-admin-full, falter-policyrouting, luci-lib-jsonc, falter-profiles, luci-lib-ipkg
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 include ../include-luci.mk
 

--- a/luci/luci-app-ffwizard-falter/luasrc/model/cbi/freifunk/assistent/changePassword.lua
+++ b/luci/luci-app-ffwizard-falter/luasrc/model/cbi/freifunk/assistent/changePassword.lua
@@ -1,5 +1,12 @@
 local uci = require "luci.model.uci".cursor()
 
+local fftools = require "luci.tools.freifunk.assistent.tools"
+
+-- check to see if the pw is already set
+if uci:get("ffwizard","settings","runbefore") and fftools.hasRootPass() then
+  luci.http.redirect(luci.dispatcher.build_url("admin/status/overview"))
+end
+
 f = SimpleForm("ffwizward", "", "")
 --change button texts
 f.submit = "Next"


### PR DESCRIPTION
Up until now, after having run the wizard, once logging in the user
would be prompted to enter a new password again.  This is now changed
via a redirect which checks to see if the password has already been set
and that the wizard has already ran.

cherry-picked from 06aa021d6534fbd96f8b77fd0385a2adae95c000 on the openwrt-19.07 branch.

Fixes: #11
Signed-off-by: pmelange <isprotejesvalkata@gmail.com>