### PR TITLE
openwrt-19.07:falter-berlin-bbbdigger: Add bbbdigger to falter package feed.

### DIFF
--- a/packages/falter-berlin-bbbdigger/Makefile
+++ b/packages/falter-berlin-bbbdigger/Makefile
@@ -1,0 +1,54 @@
+#
+# Copyright (C) 2016 Freifunk Berlin
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=falter-berlin-bbbdigger
+PKG_VERSION:=0.0.3
+PKG_RELEASE:=1
+
+PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)
+
+include $(INCLUDE_DIR)/package.mk
+
+define Package/falter-berlin-bbbdigger/default
+  SECTION:=falter-berlin
+  CATEGORY:=falter-berlin
+  URL:=http://github.com/Freifunk-Spalter/packages
+  PKGARCH:=all
+endef
+
+define Package/falter-berlin-bbbdigger
+  $(call Package/falter-berlin-bbbdigger/default)
+  TITLE:=A Tunneldigger (l2tp) based VPN connection to mesh with the Berlin Backbone
+  EXTRA_DEPENDS:=falter-berlin-tunneldigger, olsrd
+endef
+
+define Package/falter-berlin-bbbdigger/description
+  Freifunk Berlin configuration of tunneldigger to connect to and mesh with the Berlin Backbone
+endef
+
+define Build/Prepare
+endef
+
+define Build/Configure
+endef
+
+define Build/Compile
+endef
+
+define Package/falter-berlin-bbbdigger/install
+	$(INSTALL_DIR) $(1)/tmp
+	$(INSTALL_BIN) ./files/postinst.sh $(1)/tmp/falter-berlin-bbbdigger_postinst.sh
+endef
+
+define Package/falter-berlin-bbbdigger/postinst
+#!/bin/sh
+$${IPKG_INSTROOT}/tmp/falter-berlin-bbbdigger_postinst.sh
+endef
+
+$(eval $(call BuildPackage,falter-berlin-bbbdigger))

--- a/packages/falter-berlin-bbbdigger/files/postinst.sh
+++ b/packages/falter-berlin-bbbdigger/files/postinst.sh
@@ -1,0 +1,74 @@
+#!/bin/sh
+#
+# As part of the install, we don't want to smash an already set up config
+# but at the same time update it if necessary.  The unique attributes are:
+#
+# network.bbbdigger_dev.macaddr
+# tunneldigger.bbbdigger.uuid
+#
+# All other config sections are overwritten with current settings
+
+. /lib/functions.sh
+
+TUNNEL_SERV='a.bbb-vpn.berlin.freifunk.net:8942 b.bbb-vpn.berlin.freifunk.net:8942'
+IFACE=bbbdigger
+BIND=wan
+
+# tunneldigger UUID (and MAC) generation, if there isn't one already
+# See the website https://www.itwissen.info/MAC-Adresse-MAC-address.html
+MAC=$(uci -q get network.${IFACE}_dev.macaddr)
+if [ $? -eq 1 ]; then
+  # start with b6 for Berliner 6ackbone
+  MAC="b6"
+  for byte in 2 3 4 5 6; do
+    MAC=$MAC`dd if=/dev/urandom bs=1 count=1 2> /dev/null | hexdump -e '1/1 ":%02x"'`
+  done
+fi
+
+UUID=$(uci -q get tunneldigger.${IFACE}.uuid)
+if [ $? -eq 1 ]; then
+  UUID=$MAC
+  for byte in 7 8 9 10; do
+    UUID=$UUID`dd if=/dev/urandom bs=1 count=1 2> /dev/null | hexdump -e '1/1 ":%02x"'`
+  done
+fi
+
+# tunneldigger setup
+uci set tunneldigger.$IFACE=broker
+uci -q delete tunneldigger.$IFACE.address
+for srv in $TUNNEL_SERV; do
+  uci add_list tunneldigger.$IFACE.address=$srv
+done
+uci set tunneldigger.$IFACE.uuid=$UUID
+uci set tunneldigger.$IFACE.interface=$IFACE
+uci set tunneldigger.$IFACE.broker_selection=usage
+uci set tunneldigger.$IFACE.bind_interface=$BIND
+uci set tunneldigger.$IFACE.enabled=1
+
+# network setup
+uci set network.${IFACE}_dev=device
+uci set network.${IFACE}_dev.macaddr=$MAC
+uci set network.${IFACE}_dev.name=$IFACE
+
+uci set network.$IFACE=interface
+uci set network.$IFACE.proto=dhcp
+uci set network.$IFACE.ifname=$IFACE
+
+# firewall setup (first remove from the zone and add it back)
+ZONE=$(echo $(uci show firewall.zone_freifunk.network | cut -d \' -f 2 | sed "s/${IFACE}//g"))
+ZONE="$ZONE $IFACE"
+uci set firewall.zone_freifunk.network="${ZONE}"
+
+# olsr setup (first remove it and add it again)
+SECTION=$(uci show olsrd | grep ${IFACE} | cut -d . -f 1-2)
+[ ! -z $SECTION ] && uci delete $SECTION
+uci add olsrd Interface
+uci set olsrd.@Interface[-1].ignore=0
+uci set olsrd.@Interface[-1].interface=$IFACE
+uci set olsrd.@Interface[-1].Mode=ether
+
+#uci changes
+
+uci commit
+reload_config
+/etc/init.d/tunneldigger restart


### PR DESCRIPTION
bbbdigger was widely requested by several people, but missing
in falter package feed. This commit adds it.

Signed-off-by: Martin Hübner <martin.hubner@web.de>