### PR TITLE
falter-common: add /etc/profile.d/dynbanner.sh

### DIFF
--- a/packages/falter-common/Makefile
+++ b/packages/falter-common/Makefile
@@ -4,7 +4,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=falter-common
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_BUILD_DIR := $(BUILD_DIR)/$(PKG_NAME)
 

--- a/packages/falter-common/files-common/etc/profile.d/dynbanner.sh
+++ b/packages/falter-common/files-common/etc/profile.d/dynbanner.sh
@@ -1,0 +1,21 @@
+#!/bin/sh
+
+# Get dynamic information and print them under the banner.
+
+HOSTNAME=$(uci -q get system.@system[0].hostname)".olsr"
+IPADDR=$(uci -q get network.dhcp.ipaddr)
+UPTIME=$(uptime | cut -d ',' -f 0 | cut -d ' ' -f 4-)
+FREEFL=$(df -h | grep " /overlay" | sed -E -e s/[[:space:]]+/\;/g | cut -d';' -f4 )
+SYS_LOAD=$(uptime | sed -e 's/average: /;/g' | cut -d';' -f2)
+CLIENTS=$(wc -l /tmp/dhcp.leases | cut -d' ' -f1)
+
+printf \
+" Host.............................: $HOSTNAME
+ IP-Address.......................: $IPADDR
+ Uptime...........................: $UPTIME
+ Free flash.......................: $FREEFL
+ Average load (1m, 5m, 15m).......: $SYS_LOAD
+ DHCP-Clients.....................: $CLIENTS
+
+
+"


### PR DESCRIPTION
This package embeds regularily dynamic system information (i.e. system load,
uptime, amount of clients) into the banner. To protect the flash (limited amounts of writing cycles),
it uses tmpfs to store the new banner.