### PR TITLE
falter-berlin-migration: integrate new versioning

### DIFF
--- a/packages/falter-berlin-migration/Makefile
+++ b/packages/falter-berlin-migration/Makefile
@@ -1,7 +1,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=falter-berlin-migration
-PKG_VERSION:=1
+PKG_VERSION:=2
 
 PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)
 

--- a/packages/falter-berlin-migration/uci-defaults/freifunk-berlin-01-migration.sh
+++ b/packages/falter-berlin-migration/uci-defaults/freifunk-berlin-01-migration.sh
@@ -5,6 +5,12 @@ source /lib/functions/semver.sh
 source /etc/openwrt_release
 source /lib/functions/guard.sh
 
+if [ -f /etc/freifunk_release ]; then 
+  source /etc/freifunk_release
+  DISTRIB_ID="Freifunk Berlin"
+  DISTRIB_RELEASE=$FREIFUNK_RELEASE
+fi
+
 # possible cases: 
 # 1) firstboot with kathleen --> uci system.version not defined
 # 2) upgrade from kathleen --> uci system.version defined


### PR DESCRIPTION
With the creation of the file /etc/freifunk_release we
now have a method of versioning independant from openWrt.

In order for the migration script to work, the file 
/etc/freifunk_release will need to be isntalled, otherwise the
migration script will just exit.  This is for images build with
the new builter tool.

The current migration script is not yet up to date with the
current state of falter.  That shall be done later.

Signed-off-by: pmelange <isprotejesvalkata@gmail.com>