### PR TITLE
falter-berlin-migration: Hedy to falter migration, wave 1

### DIFF
--- a/packages/falter-berlin-migration/uci-defaults/freifunk-berlin-01-migration.sh
+++ b/packages/falter-berlin-migration/uci-defaults/freifunk-berlin-01-migration.sh
@@ -499,7 +499,7 @@ r1_1_0_update_dns_entry() {
   }
   reset_cb
   config_load network
-  config_foreach network_interface_delete_dns Interface
+  config_foreach network_interface_delete_dns interface
   uci set network.loopback.dns="$(uci get "profile_$(uci get freifunk.community.name).interface.dns")"
 }
 

--- a/packages/falter-berlin-migration/uci-defaults/freifunk-berlin-01-migration.sh
+++ b/packages/falter-berlin-migration/uci-defaults/freifunk-berlin-01-migration.sh
@@ -564,6 +564,28 @@ r1_1_0_wifi_iface_names() {
   config_foreach wifi_set_name wifi-iface
 }
 
+r1_1_0_ffwizard() {
+  log "adding new fields to ffwizard"
+  uci set ffwizard.upgrade="upgrade"
+
+  # add the new meshmode_$device field to settings
+  handle_wifi_iface() {
+    local config=$1
+    local mode=''
+    local device=''
+    config_get mode $config mode
+    config_get device $config device
+    [ $mode == "mesh" ] && mode="80211s"
+    [ $mode != "adhoc" ] && [ $mode != "80211s" ] && return
+
+    uci set ffwizard.settings.meshmode_${device}=${mode}
+  }
+
+  reset_cb
+  config_load wireless
+  config_foreach handle_wifi-iface wifi-iface
+}
+
 migrate () {
   log "Migrating from ${OLD_VERSION} to ${VERSION}."
 
@@ -638,6 +660,7 @@ migrate () {
     r1_1_0_statistics_server
     r1_1_0_openwrt_19_07_updates
     r1_1_0_wifi_iface_names
+    r1_1_0_ffwizard
   fi
 
   # overwrite version with the new version

--- a/packages/falter-berlin-migration/uci-defaults/freifunk-berlin-01-migration.sh
+++ b/packages/falter-berlin-migration/uci-defaults/freifunk-berlin-01-migration.sh
@@ -527,6 +527,27 @@ r1_1_0_statistics_server() {
     uci set luci_statistics.\@collectd_network_server\[0\].host=monitor.berlin.freifunk.net
 }
 
+r1_1_0_openwrt_19_07_updates() {
+  log "performing updates to openwrt 19.07."
+  uci set dhcp.@dnsmasq[0].nonwildcard="1"
+  uci set dhcp.odhcpd.loglevel="4"
+  uci set luci.main.uvuspath="/ubus/"
+  uci set luci.apply="internal"
+  uci set luci.apply.rollback="90"
+  uci set luci.apply.holdoff="4"
+  uci set luci.apply.timeout="5"
+  uci set luci.apply.display="1.5"
+  uci set luci.diag.dns="openwrt.org"
+  uci set luci.diag.ping="openwrt.org"
+  uci set luci.diag.route="openwrt.org"
+  rpcd=i$(uci add rpcd rpcd)
+  uci set rpcd.@rpcd[-1].socket="/var/run/ubus.sock"
+  uci set rpcd.@rpcd[-1].timeout="30"
+  uci add_list uhttpd.main.lua_prefix="/cgi-bin/luci=/usr/lib/lua/luci/sgi/uhttpd.lua"
+}
+
+
+
 migrate () {
   log "Migrating from ${OLD_VERSION} to ${VERSION}."
 
@@ -599,6 +620,7 @@ migrate () {
     r1_1_0_remove_olsrd_garbage_collection
     r1_1_0_firewall_remove_advanced
     r1_1_0_statistics_server
+    r1_1_0_openwrt_19_07_updates
   fi
 
   # overwrite version with the new version

--- a/packages/falter-berlin-migration/uci-defaults/freifunk-berlin-01-migration.sh
+++ b/packages/falter-berlin-migration/uci-defaults/freifunk-berlin-01-migration.sh
@@ -63,6 +63,29 @@ else
   exit 0
 fi
 
+migrate_profiles() {
+  # migrate to the latest /etc/config/profile_* and /etc/config/freifunk
+  log "Updating Community-Profiles."
+  cp /rom/etc/config/profile_* /etc/config
+
+  log "Importing updates to /etc/config/freifunk"
+  CONTACT=$(uci show freifunk.contact)
+  COMMUNITY=$(uci show freifunk.community)
+  cp /rom/etc/config/freifunk /etc/config
+  OLDIFS=$IFS
+  IFS=$'\n'
+  for i in $CONTACT $COMMUNITY; do
+    key=$(echo $i | cut -d = -f 1)
+    val=$(echo $i | cut -d = -f 2)
+    val=$(echo $val | sed s/\'//g)
+    if [ $val != "defaults" ] ; then
+      uci set $key=${val}
+    fi
+  done
+  IFS=$OLDIFS
+  uci commit freifunk
+}
+
 update_openvpn_remote_config() {
   # use dns instead of ips for vpn servers (introduced with 0.1.0)
   log "Setting openvpn.ffvpn.remote to vpn03.berlin.freifunk.net"
@@ -499,6 +522,9 @@ r1_1_0_firewall_remove_advanced() {
 
 migrate () {
   log "Migrating from ${OLD_VERSION} to ${VERSION}."
+
+  # always use the most recent profiles
+  migrate_profiles
 
   if semverLT ${OLD_VERSION} "0.1.0"; then
     update_openvpn_remote_config

--- a/packages/falter-berlin-migration/uci-defaults/freifunk-berlin-01-migration.sh
+++ b/packages/falter-berlin-migration/uci-defaults/freifunk-berlin-01-migration.sh
@@ -520,6 +520,13 @@ r1_1_0_firewall_remove_advanced() {
   config_foreach firewall_remove_advanced advanced
 }
 
+r1_1_0_statistics_server() {
+  log "Setting the statistcs server to \"monitor.berlin.freifunk.net\"."
+  local result=$(uci -q get luci_statistics.\@collectd_network_server\[0\].host)
+  [ $? -eq 0 ] && [ $result == "77.87.48.12" ] && \
+    uci set luci_statistics.\@collectd_network_server\[0\].host=monitor.berlin.freifunk.net
+}
+
 migrate () {
   log "Migrating from ${OLD_VERSION} to ${VERSION}."
 
@@ -591,6 +598,7 @@ migrate () {
     r1_1_0_update_uplink_notunnel_name
     r1_1_0_remove_olsrd_garbage_collection
     r1_1_0_firewall_remove_advanced
+    r1_1_0_statistics_server
   fi
 
   # overwrite version with the new version

--- a/packages/falter-berlin-migration/uci-defaults/zz_freifunk-berlin-migration-clean_jffs.sh
+++ b/packages/falter-berlin-migration/uci-defaults/zz_freifunk-berlin-migration-clean_jffs.sh
@@ -1,4 +1,0 @@
-#!/usr/bin/env sh
-
-# delete any overlay config files duplicated from romfs by sysupgrade - saves JFFS2 space
-cd /overlay/upper/etc/config/ && for i in *; do [ -f "$i" ] && if cmp -s "$i" "/rom/etc/config/$i"; then rm -f "$i"; fi; done;


### PR DESCRIPTION
Here is the first wave of migration scripts.  Covered are

* handle profiles
Upon upgrade, the files /etc/config/profile_* and /etc/config/freifunk are not automatically upgraded to the newest version.  This commit pulls the profile_* out of the rom partition and overwrites the profiles in /etc/config.
    
Additionally the freifunk config is handeled seperately.  This config file is a mixure of defaults with the addition of the 'contact' and 'community' sections which are configured for the running system. In this case, the version from rom is copied into /etc/config and the 'contact' and 'community' sections from the old setup are imported.

* update statistics server

* convert wireless to 802.11s
Sets all the adhoc devices to 802.11s, including changing the settings in statistics and ffwizard. This script does not check to see if 802.11s is a valid mode

* add changes to openwrt 19.07

* fix dns migration (typo)

fixes: #10 
fixes: #55 
