### PR TITLE
falter-common: set default mcast_rate for 802.11s

### DIFF
--- a/packages/falter-common/files-common/etc/config/freifunk
+++ b/packages/falter-common/files-common/etc/config/freifunk
@@ -127,4 +127,5 @@ config 'defaults' 'wifi_iface_80211s'
 	option 'encryption' 'none'
 	option 'mesh_id' 'Mesh-Freifunk'
 	option 'mesh_fwding' '0'
+	option 'mcast_rate' '12000'
 


### PR DESCRIPTION
Set the default mcast_rate for 802.11s to 12000.  This
value is derived from the experiences made at Freifunk Berlin
and the best working value for both 2.4 and 5Ghz for the
largest running 802.11s mesh-island in the network.

Signed-off-by: pmelange <isprotejesvalkata@gmail.com>