### PR TITLE
ffwizard: add manual migration steps to luci

### DIFF
--- a/luci/luci-app-ffwizard-falter/luasrc/controller/assistent/assistent.lua
+++ b/luci/luci-app-ffwizard-falter/luasrc/controller/assistent/assistent.lua
@@ -15,7 +15,7 @@ function index()
   if not nixio.fs.access("/usr/lib/lua/luci/controller/freifunk/freifunk.lua") then
     entry({"admin", "freifunk"}, firstchild(), "Freifunk", 5).dependent=false
   end
-  entry({"admin", "freifunk", "assistent"}, call("prepare"), "Freifunkassistent", 1).dependent=false
+  entry({"admin", "freifunk", "assistent"}, call("prepare"), nil, 1).dependent=false
   entry({"admin", "freifunk", "assistent", "startWizard"}, form("freifunk/assistent/startWizard"), nil, 1)
   entry({"admin", "freifunk", "assistent", "changePassword"}, form("freifunk/assistent/changePassword"), nil,5)
   entry({"admin", "freifunk", "assistent", "generalInfo"}, form("freifunk/assistent/generalInfo"), nil, 6)

--- a/luci/luci-app-ffwizard-falter/luasrc/controller/assistent/assistent.lua
+++ b/luci/luci-app-ffwizard-falter/luasrc/controller/assistent/assistent.lua
@@ -16,15 +16,25 @@ function index()
     entry({"admin", "freifunk"}, firstchild(), "Freifunk", 5).dependent=false
   end
   entry({"admin", "freifunk", "assistent"}, call("prepare"), "Freifunkassistent", 1).dependent=false
-  entry({"admin", "freifunk", "assistent", "changePassword"}, form("freifunk/assistent/changePassword"), nil,1)
-  entry({"admin", "freifunk", "assistent", "generalInfo"}, form("freifunk/assistent/generalInfo"), nil, 1)
-  entry({"admin", "freifunk", "assistent", "decide"}, template("freifunk/assistent/decide"), nil, 2)
+  entry({"admin", "freifunk", "assistent", "startWizard"}, form("freifunk/assistent/startWizard"), nil, 1)
+  entry({"admin", "freifunk", "assistent", "changePassword"}, form("freifunk/assistent/changePassword"), nil,5)
+  entry({"admin", "freifunk", "assistent", "generalInfo"}, form("freifunk/assistent/generalInfo"), nil, 6)
+  entry({"admin", "freifunk", "assistent", "decide"}, template("freifunk/assistent/decide"), nil, 7)
   entry({"admin", "freifunk", "assistent", "sharedInternet"}, form("freifunk/assistent/shareInternet"), nil, 10)
   entry({"admin", "freifunk", "assistent", "wireless"}, form("freifunk/assistent/wireless"), nil, 20)
   entry({"admin", "freifunk", "assistent", "optionalConfigs"}, form("freifunk/assistent/optionalConfigs"), nil, 20)
   entry({"admin", "freifunk", "assistent", "applyChanges"}, call("commit"), nil, 100)
   entry({"admin", "freifunk", "assistent", "reboot"}, template("freifunk/assistent/reboot"), nil, 101)
   entry({"admin", "freifunk", "assistent", "cancel"}, call("reset"), nil, 102)
+
+  -- add the upgrades
+  local upgradesDir = "/usr/lib/lua/luci/model/cbi/freifunk/upgrades/"
+  for upgrade in nixio.fs.glob(upgradesDir.."*") do
+    local upgradeName = string.gsub(upgrade,upgradesDir,"")
+    upgradeName = string.gsub(upgradeName,".lua","")
+    entry({"admin", "freifunk", "upgrades", upgradeName}, form("freifunk/upgrades/"..upgradeName), nil, 500)
+  end
+
 end
 
 function prepare()
@@ -35,7 +45,7 @@ function prepare()
     uci:commit("ffwizard")
   end
   if not uci:get("ffwizard","settings","runbefore") and not fftools.hasRootPass() then
-    luci.http.redirect(luci.dispatcher.build_url("admin/freifunk/assistent/changePassword"))
+    luci.http.redirect(luci.dispatcher.build_url("admin/freifunk/assistent/startWizard"))
   else
     luci.http.redirect(luci.dispatcher.build_url("admin/freifunk/assistent/generalInfo"))
   end

--- a/luci/luci-app-ffwizard-falter/luasrc/controller/assistent/assistent.lua
+++ b/luci/luci-app-ffwizard-falter/luasrc/controller/assistent/assistent.lua
@@ -98,6 +98,17 @@ function commit()
     uci:save("system")
   end
 
+  -- set the lastUpgrade
+  local upgradesDir = "/usr/lib/lua/luci/model/cbi/freifunk/upgrades/"
+  local upgradeName = ""
+  for upgrade in nixio.fs.glob(upgradesDir.."*") do
+    upgradeName = string.gsub(upgrade,upgradesDir,"")
+    upgradeName = string.gsub(upgradeName,".lua","")
+  end
+  uci:set("ffwizard", "upgrade", "upgrade")
+  uci:set("ffwizard", "upgrade", "lastUpgrade", upgradeName)
+  uci:save("ffwizard")
+
   firewall.configureFirewall()
 
   olsr.configureOLSR()

--- a/luci/luci-app-ffwizard-falter/luasrc/model/cbi/freifunk/assistent/changePassword.lua
+++ b/luci/luci-app-ffwizard-falter/luasrc/model/cbi/freifunk/assistent/changePassword.lua
@@ -1,12 +1,5 @@
 local uci = require "luci.model.uci".cursor()
 
-local fftools = require "luci.tools.freifunk.assistent.tools"
-
--- check to see if the pw is already set
-if uci:get("ffwizard","settings","runbefore") and fftools.hasRootPass() then
-  luci.http.redirect(luci.dispatcher.build_url("admin/status/overview"))
-end
-
 f = SimpleForm("ffwizward", "", "")
 --change button texts
 f.submit = "Next"

--- a/luci/luci-app-ffwizard-falter/luasrc/model/cbi/freifunk/assistent/startWizard.lua
+++ b/luci/luci-app-ffwizard-falter/luasrc/model/cbi/freifunk/assistent/startWizard.lua
@@ -1,0 +1,31 @@
+local uci = require "luci.model.uci".cursor()
+local fs = require "nixio.fs"
+local fftools = require "luci.tools.freifunk.assistent.tools"
+
+-- check to see if the pw is already set
+if uci:get("ffwizard","settings","runbefore") and fftools.hasRootPass() then
+
+  -- check for any upgrades
+  local lastUpgrade = uci:get("ffwizard","upgrade","lastUpgrade") or ""
+  local nextUpgrade = false
+  local upgradesDir = "/usr/lib/lua/luci/model/cbi/freifunk/upgrades/"
+  for upgrade in fs.glob(upgradesDir.."*") do
+
+    local upgradeName = string.gsub(upgrade,upgradesDir,"")                               
+    upgradeName = string.gsub(upgradeName,".lua","")                                      
+
+    if nextUpgrade or lastUpgrade == "" then
+      luci.http.redirect(luci.dispatcher.build_url("admin/freifunk/upgrades/"..upgradeName))
+    end
+
+    if upgradeName == lastUpgrade then
+      nextUpgrade = true
+    end
+  end
+
+  -- go to the status page, no wizard is needed
+  luci.http.redirect(luci.dispatcher.build_url("admin/status/overview"))
+end
+
+-- Start up the firstboot wizard
+luci.http.redirect(luci.dispatcher.build_url("admin/freifunk/assistent/changePassword"))

--- a/luci/luci-app-ffwizard-falter/luasrc/model/cbi/freifunk/upgrades/005-wireless-mesh.lua
+++ b/luci/luci-app-ffwizard-falter/luasrc/model/cbi/freifunk/upgrades/005-wireless-mesh.lua
@@ -1,0 +1,183 @@
+local fftools = require "luci.tools.freifunk.assistent.tools"
+local uci = require "luci.model.uci".cursor()
+
+f = SimpleForm("wireless", translate("Update Wireless-Mesh Settings"),
+  translate("The wireless interfaces which are built into the router can " ..
+    "mesh with other routers using either Ad-Hoc or 802.11s.  <strong> " ..
+    "802.11s is now the standard used.</strong>  But not all routers (or " ..
+    "their drivers) support this new standard.  Also, if this router " ..
+    "currently meshes with Ad-Hoc then changing it to 802.11s would cause " ..
+    "connectivity loss.  Please select which protocol to use."))
+
+local wifi_tbl = {}
+
+uci:foreach("wireless", "wifi-device",
+  function(section)
+    -- get the Frequency of the device
+    local device = section[".name"]
+    wifi_tbl[device] = section
+    local channel = tonumber(section["channel"])
+    local devicename
+    if ( channel <= 14 ) then
+      devicename = "2.4 Ghz Wifi ("..device:upper()..")"
+    else
+      devicename = "5 Ghz Wifi ("..device:upper()..")"
+    end
+
+    -- determine which mesh modes are support by this radio
+
+    -- find the wifi-iface which is either adhoc or mesh
+    uci:foreach("wireless", "wifi-iface",
+      function(ifaceSection)
+        if ( device ~= ifaceSection["device"] ) then
+          return
+        end
+        if ( "mesh" ~= ifaceSection["mode"] and "adhoc" ~= ifaceSection["mode"] ) then
+          return
+        end
+        local meshmode = f:field(ListValue, "mode_" .. device, devicename, 
+            translate("The " .. devicename .. " device is currently set to <strong>" .. 
+            ((ifaceSection["mode"] == "adhoc") and "Ad-Hoc" or "802.11s") ..
+            "</strong>. The current default setup is 802.11s.  Please select " ..
+            " how to use this device in the future. "))
+        meshmode.widget="radio"
+        meshmode:value("80211s", "802.11s")
+        meshmode:value("adhoc", translate("Ad-Hoc (outdated)"))
+        meshmode.default = "80211s" -- ifaceSection["mode"]
+        wifi_tbl[device]["oldmeshmode"] = ifaceSection["mode"]
+        wifi_tbl[device]["newmeshmode"] = meshmode
+      end)
+  end)
+
+-- "behind the scenes magic" to make the submit button do something
+main = f:field(DummyValue, "netconfig", "", "")
+main.forcewrite = true
+function main.parse(self, section)
+  local fvalue = "1"
+  if self.forcewrite then
+    self:write(section, fvalue)
+  end
+end
+-- end of "behind the scenes magic"
+
+-- write the new settings
+function main.write(self, section, value)
+  write_ffwizard(section)
+  write_wireless(section)
+  write_luci_statistics(section)
+
+  -- Run the wizard again
+  luci.http.redirect(luci.dispatcher.build_url("admin/freifunk/assistent/startWizard"))
+end
+
+function write_ffwizard(section)
+  -- set the meshmode parameter(s)
+  uci:foreach("wireless", "wifi-device",
+    function(sec)
+      local device = sec[".name"]
+      uci:set("ffwizard", "settings","meshmode_" .. device,
+        wifi_tbl[device]["newmeshmode"]:formvalue(section))
+    end)
+
+  -- mark this upgrade as the last upgrade
+  uci:set("ffwizard","upgrade","lastUpgrade","005-wireless-mesh")
+  uci:save("ffwizard")
+  uci:commit("ffwizard")
+end
+
+function write_wireless(section)
+  uci:foreach("wireless", "wifi-iface",
+    function(sec)
+      local name = sec[".name"]
+      local mode = sec["mode"]
+      local ifname = sec["ifname"]
+      local device = sec["device"]
+      local network = sec["network"]
+      local formvalue = wifi_tbl[device]["newmeshmode"]:formvalue(section)
+      local newmeshmode = formvalue
+      if ( "80211s" == newmeshmode ) then
+        newmeshmode = "mesh"
+      end
+
+      if ( "mesh" ~= mode and "adhoc" ~= mode  ) then
+        return
+      end
+      if ( mode == newmeshmode ) then
+        return
+      end
+ 
+      local mergeList = {"freifunk", "profile_"..uci:get("freifunk", "community", "name")}
+
+      local ifaceDefault
+      if formvalue ~= "adhoc" then
+         ifaceDefault = "wifi_iface_"..formvalue
+      else
+         local pre = string.sub(ifname,-1)
+         ifaceDefault = ((pre == "2") and "wifi_iface" or "wifi_iface_5")
+      end
+      local ifconfig = fftools.getMergedConfig(mergeList, "defaults", ifaceDefault)
+      ifconfig.device = device
+      ifconfig.network = network
+      ifconfig.ifname = string.gsub(ifname, mode, newmeshmode)
+      if ( newmeshmode == "adhoc" ) then
+        ifconfig.ssid = uci:get(community, "ssidscheme", devconfig.channel)
+        ifconfig.bssid = uci:get(community, "bssidscheme", devconfig.channel)
+      end
+
+      local newSectionName = string.gsub(name, mode, newmeshmode)
+
+      -- delete the old section and replace it with a new one
+      uci:delete("wireless", name)
+      uci:section("wireless", "wifi-iface", newSectionName, ifconfig)
+
+    end)
+
+    uci:save("wireless")
+    uci:commit("wireless")
+
+end
+
+function write_luci_statistics(section)
+  -- only make changes if statistics are installed
+  local ipkg = require "luci.model.ipkg"
+  if ( ipkg.installed("luci-app-statistics") ~= true ) then
+    return
+  end
+
+  -- get the old list of interfaces
+  local collectd_interface = uci:get("luci_statistics", "collectd_interface", "Interfaces")
+  local collectd_iwinfo = uci:get("luci_statistics", "collectd_iwinfo", "Interfaces")
+
+  -- update the list of interfaces
+  uci:foreach("wireless", "wifi-iface",
+    function(sec)
+      local ifname = sec["ifname"]
+      local device = sec["device"]
+      local newmeshmode = sec["mode"]
+
+      if ( "mesh" ~= newmeshmode and "adhoc" ~= newmeshmodemode  ) then
+        return
+      end 
+
+      local oldmeshmode = wifi_tbl[device]["oldmeshmode"]
+      if ( oldmeshmode == newmeshmode ) then
+        return
+      end 
+
+      local oldifname = string.gsub(ifname, newmeshmode, oldmeshmode)
+      oldifname = string.gsub(oldifname, "%-", "%%-") -- escape the '-'
+      collectd_interface, x = string.gsub(collectd_interface, oldifname, ifname)
+      collectd_iwinfo, y = string.gsub(collectd_iwinfo, oldifname, ifname)
+
+    end)
+
+  -- write the changes
+  uci:set("luci_statistics", "collectd_interface", "Interfaces", collectd_interface)
+  uci:set("luci_statistics", "collectd_iwinfo", "Interfaces", collectd_iwinfo)
+  uci:save("luci_statistics")
+  uci:commit("luci_statistics")
+end
+
+return f
+
+


### PR DESCRIPTION
Add the ability to have an after-upgrade wizard, or simply called upgrades.  In the upgrade folder lua pages can be add in further releases which will prompt the user to make a decision.  The lua pages are named NNN_task.lau.  The pages are executed in alphabetical order.

ffwizard.upgrade.lastUpgrade
An new section in the ffwizard config has been created to remember which upgrade was ran last.  This value is also set automatically upon finishing the wizard.

The migration from adhoc to 802.11s is added as a sample page.  The affected config files are ffwizard, wireless, and luci_statistics.  

As a bonus, the Freifunkassistent is removed from the menu.

This PR is dependent on PR #72. 

fixes: #66 
 