### PR TITLE
falter-packages: add /etc/freifunk_release to falter-common

### DIFF
--- a/packages/falter-common/files-common/etc/freifunk_release
+++ b/packages/falter-common/files-common/etc/freifunk_release
@@ -1,0 +1,3 @@
+FREIFUNK_RELEASE='1.2.0-snapshot'
+FREIFUNK_OPENWRT_BASE='master'
+


### PR DESCRIPTION
Set the FREIFUNK_RELEASE and FREIFUNK_OPENWRT_BASE variables
in /etc/freifunk_release.

The FREIFUNK_RELEASE variable should be in the form X.Y.Z for
a release, X.Y.Z-rcR for a release candidate, X.Y.Z-betaB for
a beta test, or X.Y.Z-snapshot for the OpenWrt snapshot releases.

The FREIFUNK_OPENWRT_BASE variable should be the name of the OpenWrt
branch that the firmware is based off of.  For example, "openwrt-19.07"
or "master"

Currently the builter repo sets this file in embedded_files.  Removing
this from builter is a requirement for merging.

Signed-off-by: pmelange <isprotejesvalkata@gmail.com>