### PR TITLE
luci-app-ffwizard-falter: check mesh modes in wizard

### DIFF
--- a/luci/luci-app-ffwizard-falter/luasrc/model/cbi/freifunk/assistent/wireless.lua
+++ b/luci/luci-app-ffwizard-falter/luasrc/model/cbi/freifunk/assistent/wireless.lua
@@ -57,9 +57,19 @@ uci:foreach("wireless", "wifi-device",
     end
     wifi_tbl[device]["meship"] = meship
 
+    local supportedModes = tools.wifi_get_mesh_modes(device)
     local meshmode = f:field(ListValue, "mode_" .. device, "Mesh Mode", "")
-    meshmode:value("80211s", "802.11s")
-    meshmode:value("adhoc", "Ad-Hoc (veraltet)")
+    meshmode.widget = "radio"
+    if supportedModes["80211s"] == true then
+      meshmode:value("80211s", "802.11s")
+      meshmode.default = "80211s"
+    end
+    if supportedModes["adhoc"] == true then
+      meshmode:value("adhoc", "Ad-Hoc (veraltet)")
+      if supportedModes["80211s"] ~= true then
+        meshmode.default = "adhoc"
+      end
+    end
     function meshmode.cfgvalue(self, section)
       return uci:get("ffwizard", "settings", "meshmode_" .. device)
     end

--- a/luci/luci-app-ffwizard-falter/luasrc/model/cbi/freifunk/upgrades/005-wireless-mesh.lua
+++ b/luci/luci-app-ffwizard-falter/luasrc/model/cbi/freifunk/upgrades/005-wireless-mesh.lua
@@ -39,7 +39,7 @@ uci:foreach("wireless", "wifi-device",
             translate("The " .. devicename .. " device is currently set to <strong>" .. 
             ((ifaceSection["mode"] == "adhoc") and "Ad-Hoc" or "802.11s") ..
             "</strong>. The current default setup is 802.11s.  Please select " ..
-            " how to use this device in the future. "))
+            "how to use this device in the future. "))
         meshmode.widget = "radio"
         local supportedModes = fftools.wifi_get_mesh_modes(device)
         if supportedModes["80211s"] == true then

--- a/luci/luci-app-ffwizard-falter/luasrc/model/cbi/freifunk/upgrades/005-wireless-mesh.lua
+++ b/luci/luci-app-ffwizard-falter/luasrc/model/cbi/freifunk/upgrades/005-wireless-mesh.lua
@@ -40,10 +40,18 @@ uci:foreach("wireless", "wifi-device",
             ((ifaceSection["mode"] == "adhoc") and "Ad-Hoc" or "802.11s") ..
             "</strong>. The current default setup is 802.11s.  Please select " ..
             " how to use this device in the future. "))
-        meshmode.widget="radio"
-        meshmode:value("80211s", "802.11s")
-        meshmode:value("adhoc", translate("Ad-Hoc (outdated)"))
-        meshmode.default = "80211s" -- ifaceSection["mode"]
+        meshmode.widget = "radio"
+        local supportedModes = fftools.wifi_get_mesh_modes(device)
+        if supportedModes["80211s"] == true then
+          meshmode:value("80211s", "802.11s")
+          meshmode.default = "80211s"
+        end
+        if supportedModes["adhoc"] == true then
+          meshmode:value("adhoc", translate("Ad-Hoc (outdated)"))
+          if supportedModes["80211s"] ~= true then
+            meshmode.default = "adhoc"
+          end
+        end
         wifi_tbl[device]["oldmeshmode"] = ifaceSection["mode"]
         wifi_tbl[device]["newmeshmode"] = meshmode
       end)

--- a/luci/luci-app-ffwizard-falter/luasrc/tools/freifunk/assistent/tools.lua
+++ b/luci/luci-app-ffwizard-falter/luasrc/tools/freifunk/assistent/tools.lua
@@ -4,6 +4,20 @@ local uci = require "luci.model.uci".cursor()
 
 module("luci.tools.freifunk.assistent.tools", package.seeall)
 
+function wifi_get_mesh_modes(device)
+	local modes = {}
+	local phy = string.gsub(device, "radio", "phy")
+	local iwOutput = sys.exec("iw phy "..phy.." info | grep -A1 \"valid interface combination\" | tail -1")
+	if string.find(iwOutput, "mesh point") then
+		modes["80211s"] = true;
+	end
+	if string.find(iwOutput, "IBSS") then
+		modes["adhoc"] = true;
+	end
+
+	return modes
+end
+
 -- Deletes all references of a wifi device
 function wifi_delete_ifaces(device)
 	local cursor = uci.cursor()


### PR DESCRIPTION
Add the ability to check the current driver to see which modes
"802.11s" or "Ad-hoc" are supported.  Only give the user the option
to select a mode if it is a valid mode.  This can be seen on
both the wireless wizard page and on the wireless mesh upgrade
page.

Signed-off-by: pmelange <isprotejesvalkata@gmail.com>