### PR TITLE
luci-app-ffwizard-falter: fix upgrade wireless-mesh

### DIFF
--- a/luci/luci-app-ffwizard-falter/luasrc/model/cbi/freifunk/assistent/wireless.lua
+++ b/luci/luci-app-ffwizard-falter/luasrc/model/cbi/freifunk/assistent/wireless.lua
@@ -57,9 +57,19 @@ uci:foreach("wireless", "wifi-device",
     end
     wifi_tbl[device]["meship"] = meship
 
+    local supportedModes = tools.wifi_get_mesh_modes(device)
     local meshmode = f:field(ListValue, "mode_" .. device, "Mesh Mode", "")
-    meshmode:value("80211s", "802.11s")
-    meshmode:value("adhoc", "Ad-Hoc (veraltet)")
+    meshmode.widget = "radio"
+    if supportedModes["80211s"] == true then
+      meshmode:value("80211s", "802.11s")
+      meshmode.default = "80211s"
+    end
+    if supportedModes["adhoc"] == true then
+      meshmode:value("adhoc", "Ad-Hoc (veraltet)")
+      if supportedModes["80211s"] ~= true then
+        meshmode.default = "adhoc"
+      end
+    end
     function meshmode.cfgvalue(self, section)
       return uci:get("ffwizard", "settings", "meshmode_" .. device)
     end

--- a/luci/luci-app-ffwizard-falter/luasrc/model/cbi/freifunk/upgrades/005-wireless-mesh.lua
+++ b/luci/luci-app-ffwizard-falter/luasrc/model/cbi/freifunk/upgrades/005-wireless-mesh.lua
@@ -39,7 +39,7 @@ uci:foreach("wireless", "wifi-device",
             translate("The " .. devicename .. " device is currently set to <strong>" .. 
             ((ifaceSection["mode"] == "adhoc") and "Ad-Hoc" or "802.11s") ..
             "</strong>. The current default setup is 802.11s.  Please select " ..
-            " how to use this device in the future. "))
+            "how to use this device in the future. "))
         meshmode.widget = "radio"
         local supportedModes = fftools.wifi_get_mesh_modes(device)
         if supportedModes["80211s"] == true then

--- a/luci/luci-app-ffwizard-falter/luasrc/model/cbi/freifunk/upgrades/005-wireless-mesh.lua
+++ b/luci/luci-app-ffwizard-falter/luasrc/model/cbi/freifunk/upgrades/005-wireless-mesh.lua
@@ -128,8 +128,9 @@ function write_wireless(section)
       ifconfig.network = network
       ifconfig.ifname = string.gsub(ifname, mode, newmeshmode)
       if ( newmeshmode == "adhoc" ) then
-        ifconfig.ssid = uci:get(community, "ssidscheme", devconfig.channel)
-        ifconfig.bssid = uci:get(community, "bssidscheme", devconfig.channel)
+        local devChannel = uci:get("wireless", device, "channel")
+        ifconfig.ssid = uci:get(community, "ssidscheme", devChannel)
+        ifconfig.bssid = uci:get(community, "bssidscheme", devChannel)
       end
 
       local newSectionName = string.gsub(name, mode, newmeshmode)

--- a/luci/luci-app-ffwizard-falter/luasrc/model/cbi/freifunk/upgrades/005-wireless-mesh.lua
+++ b/luci/luci-app-ffwizard-falter/luasrc/model/cbi/freifunk/upgrades/005-wireless-mesh.lua
@@ -40,10 +40,18 @@ uci:foreach("wireless", "wifi-device",
             ((ifaceSection["mode"] == "adhoc") and "Ad-Hoc" or "802.11s") ..
             "</strong>. The current default setup is 802.11s.  Please select " ..
             " how to use this device in the future. "))
-        meshmode.widget="radio"
-        meshmode:value("80211s", "802.11s")
-        meshmode:value("adhoc", translate("Ad-Hoc (outdated)"))
-        meshmode.default = "80211s" -- ifaceSection["mode"]
+        meshmode.widget = "radio"
+        local supportedModes = fftools.wifi_get_mesh_modes(device)
+        if supportedModes["80211s"] == true then
+          meshmode:value("80211s", "802.11s")
+          meshmode.default = "80211s"
+        end
+        if supportedModes["adhoc"] == true then
+          meshmode:value("adhoc", translate("Ad-Hoc (outdated)"))
+          if supportedModes["80211s"] ~= true then
+            meshmode.default = "adhoc"
+          end
+        end
         wifi_tbl[device]["oldmeshmode"] = ifaceSection["mode"]
         wifi_tbl[device]["newmeshmode"] = meshmode
       end)

--- a/luci/luci-app-ffwizard-falter/luasrc/tools/freifunk/assistent/tools.lua
+++ b/luci/luci-app-ffwizard-falter/luasrc/tools/freifunk/assistent/tools.lua
@@ -4,6 +4,20 @@ local uci = require "luci.model.uci".cursor()
 
 module("luci.tools.freifunk.assistent.tools", package.seeall)
 
+function wifi_get_mesh_modes(device)
+	local modes = {}
+	local phy = string.gsub(device, "radio", "phy")
+	local iwOutput = sys.exec("iw phy "..phy.." info | grep -A1 \"valid interface combination\" | tail -1")
+	if string.find(iwOutput, "mesh point") then
+		modes["80211s"] = true;
+	end
+	if string.find(iwOutput, "IBSS") then
+		modes["adhoc"] = true;
+	end
+
+	return modes
+end
+
 -- Deletes all references of a wifi device
 function wifi_delete_ifaces(device)
 	local cursor = uci.cursor()


### PR DESCRIPTION
Changing from 802.11s to adhoc fails because of an undeclared
variable.  This is a copy-paste error from the code used in the
wizard.

Error introduced in 5e8b69c5b5e02c496d74d183b97d4b0e1949bb27

Signed-off-by: pmelange <isprotejesvalkata@gmail.com>
