### PR TITLE
luci-app-ffwizard-falter: fix upgrade wireless-mesh

### DIFF
--- a/luci/luci-app-ffwizard-falter/luasrc/model/cbi/freifunk/upgrades/005-wireless-mesh.lua
+++ b/luci/luci-app-ffwizard-falter/luasrc/model/cbi/freifunk/upgrades/005-wireless-mesh.lua
@@ -128,8 +128,10 @@ function write_wireless(section)
       ifconfig.network = network
       ifconfig.ifname = string.gsub(ifname, mode, newmeshmode)
       if ( newmeshmode == "adhoc" ) then
-        ifconfig.ssid = uci:get(community, "ssidscheme", devconfig.channel)
-        ifconfig.bssid = uci:get(community, "bssidscheme", devconfig.channel)
+        local community = "profile_"..uci:get("freifunk", "community", "name")
+        local devChannel = uci:get("wireless", device, "channel")
+        ifconfig.ssid = uci:get(community, "ssidscheme", devChannel)
+        ifconfig.bssid = uci:get(community, "bssidscheme", devChannel)
       end
 
       local newSectionName = string.gsub(name, mode, newmeshmode)


### PR DESCRIPTION
Changing from 802.11s to adhoc fails because of an undeclared
variable. This is a copy-paste error from the code used in the
wizard.

Error introduced in 5e8b69c

Signed-off-by: pmelange <isprotejesvalkata@gmail.com>