### PR TITLE
falter-berlin-statistics-defaults: add dhcpleases

### DIFF
--- a/packages/falter-berlin-statistics-defaults/uci-defaults/freifunk-berlin-statistics-defaults
+++ b/packages/falter-berlin-statistics-defaults/uci-defaults/freifunk-berlin-statistics-defaults
@@ -78,4 +78,9 @@ uci set luci_statistics.$NETWORK.host=monitor.berlin.freifunk.net
 uci set luci_statistics.collectd_network=statistics
 uci set luci_statistics.collectd_network.enable=1
 
+# mod dhcpleases
+uci set luci_statistics.collectd_dhcpleases=statistics
+uci set luci_statistics.collectd_dhcpleases.enable=0
+uci set luci_statistics.collectd_dhcpleases.Path=/tmp/dhcp.leases
+
 uci commit luci_statistics


### PR DESCRIPTION
I wrote a collectd plguin for replacing the exec script. It is merged
in the master:
- https://github.com/openwrt/packages/pull/14204

The collectd upstream PR:
- https://github.com/collectd/collectd/pull/3790

We need to add "collectd-mod-dhcpleases" to packagelist.