### PR TITLE
luci-app-ffwizard-falter: fix map

### DIFF
--- a/luci/luci-app-ffwizard-falter/luasrc/view/freifunk/assistent/snippets/map.htm
+++ b/luci/luci-app-ffwizard-falter/luasrc/view/freifunk/assistent/snippets/map.htm
@@ -19,8 +19,8 @@ var initMap = function() {
 
   // init click handler
   var popup = L.popup();
-  var inputLat = document.getElementById('cbid.ffwizward.1.lat');
-  var inputLng = document.getElementById('cbid.ffwizward.1.lon');
+  var inputLat = document.getElementById('widget.cbid.ffwizward.1.lat');
+  var inputLng = document.getElementById('widget.cbid.ffwizward.1.lon');
   function onMapClick(e) {
       popup.setLatLng(e.latlng)
            .setContent(e.latlng.lat.toString() + ', ' + e.latlng.lng.toString())


### PR DESCRIPTION
Fixes #34.

When you click on the map the coordinates should be entered into the
fields above the map.

The ID was wrong. Changed to
- widget.cbid.ffwizward.1.lat
- widget.cbid.ffwizward.1.lon