### PR TITLE
Add freifunk release support to owm

### DIFF
--- a/luci/luci-app-falter-owm/Makefile
+++ b/luci/luci-app-falter-owm/Makefile
@@ -60,7 +60,6 @@ define Build/Configure
 endef
 
 define Build/Compile
-	$(MAKE) -C $(PKG_BUILD_DIR)/luasrc
 endef
 
 define Package/luci-app-falter-owm-cmd/postinst

--- a/luci/luci-app-falter-owm/luasrc/Makefile
+++ b/luci/luci-app-falter-owm/luasrc/Makefile
@@ -1,8 +1,0 @@
-LUAC = luac
-LUAC_OPTIONS = -s
-
-world: compile
-
-compile:
-	for i in $$(find -name *.lua -not -name debug.lua); do $(LUAC) $(LUAC_OPTIONS) -o $$i $$i; done
-

--- a/luci/luci-app-falter-owm/luasrc/owm.lua
+++ b/luci/luci-app-falter-owm/luasrc/owm.lua
@@ -77,6 +77,21 @@ function get_version()
 	if _G.DISTRIB_REVISION then
 		distrev = _G.DISTRIB_REVISION
 	end
+
+        -- override with values from /etc/freifunk_release if possible          
+        if nixio.fs.access("/etc/freifunk_release") then                        
+                dofile("/etc/freifunk_release")                                 
+                if _G.FREIFUNK_DISTRIB_ID then                                  
+                        distname = _G.FREIFUNK_DISTRIB_ID             
+                end                                                             
+                if _G.FREIFUNK_RELEASE then                           
+                        distrel = _G.FREIFUNK_RELEASE                      
+                end                                                             
+                if _G.FREIFUNK_REVISION then                                    
+                        distrev = _G.FREIFUNK_REVISION                       
+                end                                                             
+        end                                                                     
+
 	version['distname'] = distname
 	version['distrevision'] = distrev
 	return version


### PR DESCRIPTION
Use the values in /etc/freifunk_release in the data sent by /usr/sbin/owm.lua.  If the file does not exist, the program runs like always.

Additionally, stop compiling the lua source.

fixes #96 