### PR TITLE
freifunk-berlin-dhcp-defaults: dnsmasq: ignore wan

### DIFF
--- a/packages/falter-berlin-dhcp-defaults/uci-defaults/freifunk-berlin-dhcp-defaults
+++ b/packages/falter-berlin-dhcp-defaults/uci-defaults/freifunk-berlin-dhcp-defaults
@@ -6,6 +6,10 @@ guard "dhcp"
 # quieten down dnsmasq a bit (do not log lease-mgmt)
 uci set dhcp.@dnsmasq[0].quietdhcp=1
 
+# dnsmasq should not care for 'wan',
+# prevents: daemon.warn dnsmasq-dhcp: DHCP packet received on xxx-wan which has no address.
+uci add_list dhcp.@dnsmasq[0].notinterface='wan'
+
 # on IPv6-islands we also should give a default-route to the clients,
 # so they can also reach IPv6-neighbours. 
 uci set dhcp.dhcp.ra_default=1


### PR DESCRIPTION
What is the problem?
syslog is spammed by: daemon.warn dnsmasq-dhcp: DHCP packet received on xxx-wan which has no address

What is the expected behaviour?
dnsmasq should not care / be silent for 'wan'

Signed-off-by: everloop2 <25203855+everloop2@users.noreply.github.com>