### PR TITLE
fater-berlin.statistics-defaults: set option ValuesAbsolute=1 in luci_statistics

### DIFF
--- a/packages/falter-berlin-migration/uci-defaults/freifunk-berlin-01-migration.sh
+++ b/packages/falter-berlin-migration/uci-defaults/freifunk-berlin-01-migration.sh
@@ -616,6 +616,11 @@ r1_1_0_ffwizard() {
   config_foreach handle_wifi-iface wifi-iface
 }
 
+r1_1_0_statistics() {
+  log "adding new options to luci_statistics"
+  uci -q set luci_statistics.collectd_memory.ValuesAbsolute=1
+}
+
 migrate () {
   log "Migrating from ${OLD_VERSION} to ${VERSION}."
 
@@ -691,6 +696,7 @@ migrate () {
     r1_1_0_openwrt_19_07_updates
     r1_1_0_wifi_iface_names
     r1_1_0_ffwizard
+    r1_1_0_statistics
   fi
 
   # overwrite version with the new version

--- a/packages/falter-berlin-statistics-defaults/uci-defaults/freifunk-berlin-statistics-defaults
+++ b/packages/falter-berlin-statistics-defaults/uci-defaults/freifunk-berlin-statistics-defaults
@@ -57,6 +57,7 @@ uci set luci_statistics.collectd_rrdtool.RRATimespans="1hour 1day 1week 1month 1
 # mod memory
 uci set luci_statistics.collectd_memory=statistics
 uci set luci_statistics.collectd_memory.enable=1
+uci set luci_statistics.collectd_memory.ValuesAbsolute=1
 
 # mod olsrd - depends on olsrd-plugin-txtinfo
 uci set luci_statistics.collectd_olsrd=statistics


### PR DESCRIPTION
falter-berlin-statistics-defaults: Update default for memory plugin
Add the option ValuesAbsolute=1 to the memory plugin

falter-berlin-migration: add statistics migration

Fixes: #112 