### PR TITLE
falter-berlin-uplink-notunnel: disable tunneldigger setting for ffuplink

### DIFF
--- a/packages/falter-berlin-uplink-notunnel/uci-defaults/freifunk-berlin-z95_notunnel
+++ b/packages/falter-berlin-uplink-notunnel/uci-defaults/freifunk-berlin-z95_notunnel
@@ -23,6 +23,12 @@ fi
 # set set auth-type required for this uplink-type, e.g. for freifunk-wizard
 uci set ffberlin-uplink.uplink.auth=none
 
+# disable tunneldigger for ffuplink, if tunneldigger was the previous setup
+if [ ${current_preset} == "tunnelberlin_tunneldigger" ]; then
+  uci set tunneldigger.ffuplink.enabled=0
+  uci commit tunneldigger
+fi
+
 macaddr=$(uci -q get ffberlin-uplink.uplink.macaddr)
 if [ -z "$macaddr" ]; then
   macaddr=$(generate_random_mac_hex "fe")


### PR DESCRIPTION
When switching from tunneldigger to notunnel, the setting in tunneldigger
for the ffuplink should be disabled.  Without disabling this, the
notunnel setting for ffuplink will not work properly.

Fixes: #119
Signed-off-by: pmelange <isprotejesvalkata@gmail.com>