### PR TITLE
luci-app-ffwizard-falter: fix wireless-mesh settings page

### DIFF
--- a/luci/luci-app-ffwizard-falter/luasrc/model/cbi/freifunk/wireless-mesh.lua
+++ b/luci/luci-app-ffwizard-falter/luasrc/model/cbi/freifunk/wireless-mesh.lua
@@ -132,8 +132,8 @@ function write_wireless(section)
       if ( newmeshmode == "adhoc" ) then
         local community = "profile_"..uci:get("freifunk", "community", "name")
         local devChannel = uci:get("wireless", device, "channel")
-        ifconfig.ssid = uci:get(community, "ssidscheme", devconfig.channel)
-        ifconfig.bssid = uci:get(community, "bssidscheme", devconfig.channel)
+        ifconfig.ssid = uci:get(community, "ssidscheme", devChannel)
+        ifconfig.bssid = uci:get(community, "bssidscheme", devChannel)
       end
 
       local newSectionName = string.gsub(name, mode, newmeshmode)


### PR DESCRIPTION
the variable devconfig.channel was referenced, but is undefined.  Use
devChannel instead

Fixes: #121
Signed-off-by: pmelange <isprotejesvalkata@gmail.com>