### PR TITLE
Disable ffuplink interface durring initial setup

### DIFF
--- a/luci/luci-app-ffwizard-falter/Makefile
+++ b/luci/luci-app-ffwizard-falter/Makefile
@@ -2,7 +2,7 @@ include $(TOPDIR)/rules.mk
 
 LUCI_TITLE:=Freifunk Berlin configuration wizard
 LUCI_EXTRA_DEPENDS:=luci-compat, luci-mod-admin-full, falter-policyrouting, luci-lib-jsonc, falter-profiles, luci-lib-ipkg
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 include ../include-luci.mk
 

--- a/luci/luci-app-ffwizard-falter/luasrc/model/cbi/freifunk/assistent/wireless.lua
+++ b/luci/luci-app-ffwizard-falter/luasrc/model/cbi/freifunk/assistent/wireless.lua
@@ -115,6 +115,11 @@ function main.write(self, section, value)
     --share internet was not enabled before, set to false now
     uci:set("ffwizard", "settings", "sharenet", "0")
     uci:save("ffwizard")
+    --in case the wizard has been re-ran, ensure ffuplink is disabled
+    uci:set("network", "ffuplink", "disabled", "1")
+  else
+    --sharenet was enabled, therefore enable the ffuplink network interface
+    uci:set("network", "ffuplink", "disabled", "0")
   end
 
   -- store wizard data to fill fields if wizard is rerun

--- a/packages/falter-berlin-network-defaults/Makefile
+++ b/packages/falter-berlin-network-defaults/Makefile
@@ -1,7 +1,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=falter-berlin-network-defaults
-PKG_VERSION:=2
+PKG_VERSION:=3
 
 include $(INCLUDE_DIR)/package.mk
 

--- a/packages/falter-berlin-network-defaults/uci-defaults/freifunk-berlin-ffuplink-defaults
+++ b/packages/falter-berlin-network-defaults/uci-defaults/freifunk-berlin-ffuplink-defaults
@@ -15,3 +15,6 @@ uci set ffberlin-uplink.uplink.auth=none
 uci commit ffberlin-uplink
 
 create_ffuplink
+uci set network.ffuplink.disabled=1
+uci commit network.ffuplink
+


### PR DESCRIPTION
falter-berlin-network-defaults: disable ffuplink per default
    
disable the ffuplink per default and only activate it if the user decides to activate the ffuplink interface in the wizard by choosing to share the internet connection
    
luci-app-ffwizard-falter: only enable ffuplink when chosen
    
only enable the ffuplink interface if the user decides to share their internet connection.
    
Fixes #123 