### PR TITLE
luci-app-olsr2: move LUCI_DEPENDS to LUCI_EXTRA_DEPENDS

### DIFF
--- a/luci/luci-app-olsr2/Makefile
+++ b/luci/luci-app-olsr2/Makefile
@@ -7,7 +7,8 @@
 include $(TOPDIR)/rules.mk
 
 LUCI_TITLE:=OLSRv2 status module
-LUCI_DEPENDS:=+luci-compat +oonf-olsrd2 +luci-lib-json
+LUCI_EXTRA_DEPENDS:=+luci-compat +oonf-olsrd2 +luci-lib-json
+PKG_RELEASE:=2
 
 include ../include-luci.mk
 


### PR DESCRIPTION
Move the dependencies from LUCI_DEPENDS to LUCI_EXTRA_DEPENDS to reduce
the amount of compile-time dependencies

Fixes: #105
Signed-off-by: pmelange <isprotejesvalkata@gmail.com>