### PR TITLE
falter-berlin-migration: handle sharenet

### DIFF
--- a/packages/falter-berlin-migration/uci-defaults/freifunk-berlin-01-migration.sh
+++ b/packages/falter-berlin-migration/uci-defaults/freifunk-berlin-01-migration.sh
@@ -621,6 +621,17 @@ r1_1_0_statistics() {
   uci -q set luci_statistics.collectd_memory.ValuesAbsolute=1
 }
 
+r1_1_0_sharenet_setup() {
+  local sharenet=$(uci get ffwizard.settings.sharenet)
+  if [ 1 -ne $sharenet ]; then
+    log "disabling ffuplink because sharenet is not set to 1"
+    uci set network.ffuplink.disabled=1
+  else
+    log "enabling ffuplink because sharenet is set to 1"
+    uci set network.ffuplink.disabled=0
+  fi
+}
+
 migrate () {
   log "Migrating from ${OLD_VERSION} to ${VERSION}."
 
@@ -697,6 +708,7 @@ migrate () {
     r1_1_0_wifi_iface_names
     r1_1_0_ffwizard
     r1_1_0_statistics
+    r1_1_0_nosharenet_setup
   fi
 
   # overwrite version with the new version


### PR DESCRIPTION
when ffwizard.settings.sharenet is not set to 1 (don't share),
then set the ffuplink interface to disabled=1.  Otherwise the
policy routing will not provide internet (desired) but still
olsrd will advertise and up (black hole/not desired).

if sharing is desired (set to 1), then explicitly set the ffupink
to disabled=0

Fixes: #126
Signed-off-by: pmelange <isprotejesvalkata@gmail.com>