### PR TITLE
falter-berlin-network-defaults: no peerdns for ffuplink

### DIFF
--- a/packages/falter-berlin-network-defaults/lib/functions/freifunk-berlin-network.sh
+++ b/packages/falter-berlin-network-defaults/lib/functions/freifunk-berlin-network.sh
@@ -7,6 +7,7 @@ create_ffuplink() {
   # create a very basic ffuplink interface
   uci set network.ffuplink=interface
   uci set network.ffuplink.ifname=ffuplink
+  uci set network.ffuplink.peerdns=0
   # see https://github.com/freifunk-berlin/firmware/issues/561
   uci set network.ffuplink.ip4table=ffuplink
   uci set network.ffuplink.ip6table=ffuplink


### PR DESCRIPTION
set the option peerdns to 0 for ffuplink.  This prevents the interface
from adding the local router's advertised DNS servers to dnsmasq running
on the router.  This only has a real impact on the notunnel version as
none of the tunneldigger servers advertise DNS.

Fixes: #130
Signed-off-by: pmelange <isprotejesvalkata@gmail.com>