### PR TITLE
luci-mod-falter: add BBB-VPN (bbbdigger) config page

### DIFF
--- a/luci/luci-mod-falter/Makefile
+++ b/luci/luci-mod-falter/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 LUCI_TITLE:=Freifunk Public and Admin LuCI UI
 LUCI_EXTRA_DEPENDS:=luci-mod-admin-full, luci-lib-json, falter-profiles, luci-lib-ipkg, luci-compat
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 include ../include-luci.mk
 

--- a/luci/luci-mod-falter/luasrc/controller/freifunk/freifunk.lua
+++ b/luci/luci-mod-falter/luasrc/controller/freifunk/freifunk.lua
@@ -103,6 +103,11 @@ function index()
 	page.title  = _("Wireless Mesh")
 	page.order  = 30
 
+	page        = node("admin", "freifunk", "bbbdigger")
+	page.target = cbi("freifunk/bbbdigger", {hideapplybtn=true})
+	page.title  = _("BBB-VPN (bbbdigger)")
+	page.order  = 35
+
 	entry({"freifunk", "map"}, template("freifunk-map/frame"), _("Map"), 50)
 	entry({"freifunk", "map", "content"}, template("freifunk-map/map"), nil, 51)
 	entry({"admin", "freifunk", "profile_error"}, template("freifunk/profile_error"))

--- a/luci/luci-mod-falter/luasrc/model/cbi/freifunk/bbbdigger.lua
+++ b/luci/luci-mod-falter/luasrc/model/cbi/freifunk/bbbdigger.lua
@@ -1,0 +1,124 @@
+local sys = require "luci.sys"
+local uci = require "luci.model.uci".cursor()
+
+m = Map("ffwizard", translate("BBB-VPN (bbbdigger) Settings"), nil)
+
+f = m:section(NamedSection, "settings", "settings",
+  translate("BBB-VPN (bbbdigger) Settings"),
+  translate("To enable island nodes of the Berlin Freifunk Network " ..
+    "to be able to virtually mesh with the Berlin Backbone (BBB), " ..
+    "BBB-VPN servers have been set up to allow meshing through " ..
+    "a VPN using tunneldigger (bbbdigger).  The BBB-VPN servers run " ..
+    "a modified version of OLSRd which blocks any gateway advertisements " ..
+    "and does not allow the VPN clients to see each other as direct " ..
+    "neighbors.<br><br>Using bbbdigger will add a constant amount of " ..
+    "background traffic going over the WAN interface of the router. So " ..
+    "it is not recommended for devices which have metered internet access."))
+
+-- origStatus 1=disabled 0=enabled nil=not found (treat as disabled)
+local origStatus = uci:get("network", "bbbdigger", "disabled")
+local oldStatus = origStatus or "1"
+
+local status = f:option(ListValue, "bbbdigger",
+               translate("Conntecting to the BBB-VPN"),
+               translate("Upon submission you will be redirected to the " ..
+                         "OLSRd Neighbors page.  There you will be able " ..
+                         "to see the effects of enabling/disabling " ..
+                         "bbbdigger.  It may take up to 60 seconds after " ..
+                         "enabling to see any results"))
+status.widget = "radio"
+status:value(0, "enabled")
+status:value(1, "disabled")
+status.default = oldStatus
+
+-- "behind the scenes magic" to make the submit button do something
+main = f:option(DummyValue, "netconfig", "", "")
+main.forcewrite = true
+function main.parse(self, section)
+  local fvalue = "1"
+  if self.forcewrite then
+    self:write(section, fvalue)
+  end
+end
+-- end of "behind the scenes magic"
+
+-- write the new settings
+function main.write(self, section, value)
+  local oldStatus = tonumber(oldStatus)
+  local newStatus = tonumber(status:formvalue(section))
+
+  if (oldStatus ~= newStatus) then
+    if (newStatus == 1) then 
+      -- bbbdigger must have been set up in the past, just disable it
+      -- and restart tunneldigger to take down the l2tp interface
+      uci:set("network", "bbbdigger", "disabled", "1")
+      uci:set("tunneldigger", "bbbdigger", "enabled", "0")
+      uci:set("olsrd", "bbbdigger", "ignore", "1")
+    elseif (origStatus ~= nil) then -- reenable
+      -- bbbdigger has been set up before, then disabled.  Simply reenable it
+      uci:set("network", "bbbdigger", "disabled", "0")
+      uci:set("tunneldigger", "bbbdigger", "enabled", "1")
+      uci:set("olsrd", "bbbdigger", "ignore", "0")
+    else
+      -- create the device
+      local mac = "b6" -- start with b6 for Berlin 6ackbone
+      for byte=2,6 do
+        mac = mac .. sys.exec("dd if=/dev/urandom bs=1 count=1 2> /dev/null | hexdump -e '1/1 \":%02x\"'")
+      end
+      uci:set("network", "bbbdigger_dev", "device")
+      uci:set("network", "bbbdigger_dev", "macaddr", mac)
+      uci:set("network", "bbbdigger_dev", "name", "bbbdiggger")
+
+      -- create the interface
+      uci:set("network", "bbbdigger", "interface")
+      uci:set("network", "bbbdigger", "proto", "dhcp")
+      uci:set("network", "bbbdigger", "ifname", "bbbdigger")
+      uci:set("network", "bbbdigger", "disabled", "0")
+
+      -- create the tunneldigger section
+      local uuid = mac
+      for byte=7,10 do
+        uuid = uuid .. sys.exec("dd if=/dev/urandom bs=1 count=1 2> /dev/null | hexdump -e '1/1 \":%02x\"'")
+      end
+      uci:set("tunneldigger", "bbbdigger", "broker")
+      uci:set("tunneldigger", "bbbdigger", "address", { 
+        "a.bbb-vpn.berlin.freifunk.net:8942", 
+        "b.bbb-vpn.berlin.freifunk.net:8942" } )
+      uci:set("tunneldigger", "bbbdigger", "uuid", uuid)
+      uci:set("tunneldigger", "bbbdigger", "interface", "bbbdigger")
+      uci:set("tunneldigger", "bbbdigger", "broker_selection", "usage")
+      uci:set("tunneldigger", "bbbdigger", "bind_interface", "wan")
+      uci:set("tunneldigger", "bbbdigger", "enabled", "1")
+
+      -- add bbbdigger to the freifunk firewall zone
+      local fwzone = uci:get("firewall", "zone_freifunk", "network")
+      uci:set("firewall", "zone_freifunk", "network", fwzone .. " bbbdigger")
+
+      -- add bbbdigger to olsrd
+      local olsrif = uci:set("olsrd", "bbbdigger", "Interface")
+      uci:set("olsrd", "bbbdigger", "ignore", "0")
+      uci:set("olsrd", "bbbdigger", "interface", "bbbdigger")
+      uci:set("olsrd", "bbbdigger", "Mode", "ether")
+    end
+
+    -- wrap it up
+    uci:save("network")
+    uci:save("tunneldigger")
+    uci:save("firewall")
+    uci:save("olsrd")
+    uci:commit("network")
+    uci:commit("tunneldigger")
+    uci:commit("firewall")
+    uci:commit("olsrd")
+    sys.exec("/etc/init.d/tunneldigger restart")
+
+  end
+
+  -- don't save to ffwizard.settings.bbbdigger
+  uci:revert("ffwizard")
+  
+  luci.http.redirect(luci.dispatcher.build_url("admin/status/olsr/neighbors"))
+end
+
+return f
+

--- a/luci/luci-mod-falter/root/usr/share/rpcd/acl.d/luci-mod-falter.json
+++ b/luci/luci-mod-falter/root/usr/share/rpcd/acl.d/luci-mod-falter.json
@@ -18,8 +18,8 @@
                                 "network",
                                 "qos",
                                 "luci_statistics",
-                                "openvpn"
-
+                                "openvpn",
+                                "tunneldigger"
                         ],
                         "files" : {
                                 "/etc/config/ffwizard": [
@@ -58,7 +58,8 @@
                                 "network",
                                 "qos",
                                 "luci_statistics",
-                                "openvpn"
+                                "openvpn",
+                                "tunneldigger"
                         ],
                         "files" : {
                                 "/etc/config/ffwizard": [


### PR DESCRIPTION
Add the ability to enable (create if not already created) or
disable the bbbdigger interface.  If the interface and related
settings have not been created before, use the default values
hard coded into the page.  If the interface and related settings
have been created before, simple toggle between disabled=1 and
disabled=0 as necessary.

This is a very Berlin centric page and is not easily portable
to other communities.  If portablility to other communitites is
required, then a rework of the settings should be considered.

Fixes: #54
Signed-off-by: pmelange <isprotejesvalkata@gmail.com>