### PR TITLE
luci-mod-falter: add index_user.html to sysupgrade keep list

### DIFF
--- a/luci/luci-mod-falter/root/lib/upgrade/keep.d/freifunk
+++ b/luci/luci-mod-falter/root/lib/upgrade/keep.d/freifunk
@@ -1,0 +1,2 @@
+/www/luci-static/index_user.html
+


### PR DESCRIPTION
add the file /www/luci-static/index_user.html to /lib/upgrade/keep.d
to ensure that after an upgrade "user defined inex pages" are kept.

Fixes: #147
Signed-off-by: pmelange <isprotejesvalkata@gmail.com>