### PR TITLE
luci-app-falter-owm: fix crash on empty lat/lon

### DIFF
--- a/luci/luci-app-falter-owm/luasrc/owm.lua
+++ b/luci/luci-app-falter-owm/luasrc/owm.lua
@@ -303,9 +303,11 @@ function get()
 		root.freifunk[pname] = s
 	end)
 
-	root.latitude = position["latitude"] --owm
-	root.longitude = position["longitude"] --owm                                                        
-													
+	if position ~= nil then
+		root.latitude = position["latitude"] --owm
+		root.longitude = position["longitude"] --owm                                                        
+	end
+		
 	root.links = fetch_olsrd_neighbors({})                                                                        
 	root.olsr = fetch_olsrd()                                                                      
 	root.script = 'luci-app-owm'                    


### PR DESCRIPTION
luci-app-falter-owm: fix crash on empty lat/lon

$(only set latitude and longitude if we have a valid, non empty position)

Fixes #136

Signed-off-by: Tobias Schwarz info@tobias-schwarz.com