### PR TITLE
luci-app-falter-owm: fix crash on empty lat/lon

### DIFF
--- a/luci/luci-app-falter-owm/luasrc/owm.lua
+++ b/luci/luci-app-falter-owm/luasrc/owm.lua
@@ -303,8 +303,10 @@ function get()
 		root.freifunk[pname] = s
 	end)
 
-	root.latitude = position["latitude"] --owm
-	root.longitude = position["longitude"] --owm                                                        
+	if position ~= nil then
+		root.latitude = position["latitude"] --owm
+		root.longitude = position["longitude"] --owm                                                        
+	end                                                       
 													
 	root.links = fetch_olsrd_neighbors({})                                                                        
 	root.olsr = fetch_olsrd()                                                                      


### PR DESCRIPTION
$(check for nil position and do not set position then)

Fixes #136

Signed-off-by: Tobias Schwarz <info@tobias-schwarz.com>