### PR TITLE
falter-common: suppress error on missing file

### DIFF
--- a/packages/falter-common/files-common/etc/profile.d/dynbanner.sh
+++ b/packages/falter-common/files-common/etc/profile.d/dynbanner.sh
@@ -4,10 +4,10 @@
 
 HOSTNAME=$(uci -q get system.@system[0].hostname)".olsr"
 IPADDR=$(uci -q get network.dhcp.ipaddr)
-UPTIME=$(uptime | cut -d ',' -f 0 | cut -d ' ' -f 4-)
-FREEFL=$(df -h | grep " /overlay" | sed -E -e s/[[:space:]]+/\;/g | cut -d';' -f4 )
-SYS_LOAD=$(uptime | sed -e 's/average: /;/g' | cut -d';' -f2)
-CLIENTS=$(wc -l /tmp/dhcp.leases | cut -d' ' -f1)
+UPTIME=$(uptime | cut -d ',' -f 0 | cut -d ' ' -f 4-) 2&> /dev/null
+FREEFL=$(df -h | grep " /overlay" | sed -E -e s/[[:space:]]+/\;/g | cut -d';' -f4 ) 2&> /dev/null
+SYS_LOAD=$(cat /proc/loadavg | cut -d' ' -f 1-3) 2&> /dev/null
+CLIENTS=$(wc -l /tmp/dhcp.leases | cut -d' ' -f1) 2&> /dev/null
 
 printf \
 " Host.............................: $HOSTNAME


### PR DESCRIPTION
For nodes that do not host a DHCP-Server count the clients will produce
an error message, as the file /tmp/dhcp.leases doesn't exist. The error
shouldn't appear in the dynbanner. Thus we suppress it by piping the error
output to /dev/null.

Fixes #157.

Signed-off-by: Martin Hübner <martin.hubner@web.de>