### PR TITLE
rssid_led: CPExxx workaround high cpu load bug

### DIFF
--- a/packages/falter-berlin-system-defaults/uci-defaults/freifunk-berlin-system-defaults
+++ b/packages/falter-berlin-system-defaults/uci-defaults/freifunk-berlin-system-defaults
@@ -8,6 +8,12 @@ if [ $(uci get system.@system[0].hostname) = OpenWrt ]; then
   uci commit system
 fi
 
+# led: set rssid_wlan0 to wlan0-mesh-2, workaround for high cpu load bug (https://github.com/Freifunk-Spalter/packages/issues/142)
+if [ $(uci get system.@rssid[0].dev) = wlan0 ]; then
+  uci set system.@rssid[0].dev=wlan0-mesh-2
+  uci commit system
+fi
+
 guard "system"
 
 uci set system.ntp.use_dhcp='0'


### PR DESCRIPTION
Workaround for high cpu load bug till https://bugs.openwrt.org/index.php?do=details&task_id=3708 is fixed.

In /etc/config/system change rssid_wlan0 option dev 'wlan0' to 'wlan0-mesh-2'.

Fixes https://github.com/Freifunk-Spalter/packages/issues/142.

Signed-off-by: everloop2 <25203855+everloop2@users.noreply.github.com>