### PR TITLE
RSSI Led device setting

### DIFF
--- a/luci/luci-app-ffwizard-falter/Makefile
+++ b/luci/luci-app-ffwizard-falter/Makefile
@@ -2,7 +2,7 @@ include $(TOPDIR)/rules.mk
 
 LUCI_TITLE:=Freifunk Berlin configuration wizard
 LUCI_EXTRA_DEPENDS:=luci-compat, luci-mod-admin-full, falter-policyrouting, luci-lib-jsonc, falter-profiles, luci-lib-ipkg
-PKG_RELEASE:=3
+PKG_RELEASE:=4
 
 include ../include-luci.mk
 

--- a/luci/luci-app-ffwizard-falter/luasrc/model/cbi/freifunk/assistent/wireless.lua
+++ b/luci/luci-app-ffwizard-falter/luasrc/model/cbi/freifunk/assistent/wireless.lua
@@ -205,6 +205,12 @@ function main.write(self, section, value)
         tools.statistics_interface_add("collectd_interface", ifnameMesh)
       end
 
+      --RSSI LED settings
+      local rssiled = uci:get("system", "rssid_"..calcifcfg(device), "dev")
+      if rssiled then
+        uci:set("system", "rssid_"..calcifcfg(device), "dev", ifconfig.ifname)
+      end
+
       --NETWORK CONFIG mesh
       local node_ip = wifi_tbl[device]["meship"]:formvalue(section)
       node_ip = ip.IPv4(node_ip)
@@ -235,6 +241,7 @@ function main.write(self, section, value)
       uci:save("firewall")
       uci:save("olsrd")
       uci:save("olsrd6")
+      uci:save("system")
       uci:save("wireless")
       uci:save("network")
       if statistics_installed then

--- a/luci/luci-app-ffwizard-falter/luasrc/model/cbi/freifunk/upgrades/005-wireless-mesh.lua
+++ b/luci/luci-app-ffwizard-falter/luasrc/model/cbi/freifunk/upgrades/005-wireless-mesh.lua
@@ -143,9 +143,18 @@ function write_wireless(section)
       uci:delete("wireless", name)
       uci:section("wireless", "wifi-iface", newSectionName, ifconfig)
 
+      -- RSSI LED setting
+      local rssidev = string.sub(ifconfig.ifname,
+                                 string.find(ifconfig.ifname, "wlan%d"))
+      local rssiled = uci:get("system", "rssid_"..rssidev, "dev")
+      if rssiled then
+        uci:set("system", "rssid_"..rssidev, "dev", ifconfig.ifname)
+      end
     end)
 
+    uci:save("system")
     uci:save("wireless")
+    uci:commit("system")
     uci:commit("wireless")
 
 end

--- a/luci/luci-mod-falter/Makefile
+++ b/luci/luci-mod-falter/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 LUCI_TITLE:=Freifunk Public and Admin LuCI UI
 LUCI_EXTRA_DEPENDS:=luci-mod-admin-full, luci-lib-json, falter-profiles, luci-lib-ipkg, luci-compat
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 include ../include-luci.mk
 

--- a/luci/luci-mod-falter/luasrc/model/cbi/freifunk/wireless-mesh.lua
+++ b/luci/luci-mod-falter/luasrc/model/cbi/freifunk/wireless-mesh.lua
@@ -142,9 +142,19 @@ function write_wireless(section)
       uci:delete("wireless", name)
       uci:section("wireless", "wifi-iface", newSectionName, ifconfig)
 
+      -- RSSI LED setting
+      local rssidev = string.sub(ifconfig.ifname,
+                                 string.find(ifconfig.ifname, "wlan%d"))
+      local rssiled = uci:get("system", "rssid_"..rssidev, "dev")
+      if rssiled then
+        uci:set("system", "rssid_"..rssidev, "dev", ifconfig.ifname)
+      end
+
     end)
 
+    uci:save("system")
     uci:save("wireless")
+    uci:commit("system")
     uci:commit("wireless")
 
 end

--- a/packages/falter-berlin-migration/Makefile
+++ b/packages/falter-berlin-migration/Makefile
@@ -1,7 +1,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=falter-berlin-migration
-PKG_VERSION:=2
+PKG_VERSION:=3
 
 PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)
 


### PR DESCRIPTION
Maintainer: me
Compile tested: None, only run tested
Run tested: TP-Link CPE210 V1, Falter Firmware 1.1.0

Description:
The RSSI Leds will cause a high load when the referenced device (system.rssi_$WLAN.dev) is not set to a proper wlan interface.  These commits will set the RSSI Leds device to the wireless mesh interface (either adhoc or 802.11s).

Fixes: #142 