### PR TITLE
luci-mod-falter: add bandwidth settings page

### DIFF
--- a/luci/luci-mod-falter/Makefile
+++ b/luci/luci-mod-falter/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 LUCI_TITLE:=Freifunk Public and Admin LuCI UI
 LUCI_EXTRA_DEPENDS:=luci-mod-admin-full, luci-lib-json, falter-profiles, luci-lib-ipkg, luci-compat
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 include ../include-luci.mk
 

--- a/luci/luci-mod-falter/luasrc/controller/freifunk/freifunk.lua
+++ b/luci/luci-mod-falter/luasrc/controller/freifunk/freifunk.lua
@@ -103,10 +103,15 @@ function index()
 	page.title  = _("Wireless Mesh")
 	page.order  = 30
 
+        page        = node("admin", "freifunk", "bandwidth")
+        page.target = cbi("freifunk/bandwidth", {hideapplybtn=true})
+        page.title  = _("Bandwidth")
+        page.order  = 35
+
 	page        = node("admin", "freifunk", "bbbdigger")
 	page.target = cbi("freifunk/bbbdigger", {hideapplybtn=true})
 	page.title  = _("BBB-VPN (bbbdigger)")
-	page.order  = 35
+	page.order  = 40
 
 	entry({"freifunk", "map"}, template("freifunk-map/frame"), _("Map"), 50)
 	entry({"freifunk", "map", "content"}, template("freifunk-map/map"), nil, 51)

--- a/luci/luci-mod-falter/luasrc/model/cbi/freifunk/bandwidth.lua
+++ b/luci/luci-mod-falter/luasrc/model/cbi/freifunk/bandwidth.lua
@@ -1,0 +1,63 @@
+local uci = require "luci.model.uci".cursor()
+
+m = Map("ffwizard", translate("Bandwidth Settings"), nil)
+
+f = m:section(NamedSection, "settings", "settings",
+  translate("Bandwidth Settings"),
+  translate("The nodes of the Freifunk network foward data based on " ..
+            "shortest paths and highest bandwidth. Therefor we need " ..
+            "to know, how much bandwidth to the internet there is and " ..
+            "how much do you want to share. Typical values are 6.0 " ..
+            "Mbit/s download and 0.5 Mbit/s upload with <em>DSL 6000</em> " ..
+            "or 50.0 Mbit/s download and 10.0 Mbit/s upload with " ..
+            "<em>VDSL 50000</em>. Preferably you test the actual bandwidth " ..
+            "multiple time with a tool like <em>speedof.me</em>. Then you " ..
+            "can fill in how much bandwidth you are willing to share with " ..
+            "your peers. Please be generous, but don't overestimate. :-)"))
+
+local usersBandwidthDown = f:option(Value, "usersBandwidthDown",
+    translate("Download-Bandwith in Mbit/s"))
+usersBandwidthDown.datatype = "float"
+usersBandwidthDown.rmempty = false
+
+local usersBandwidthUp = f:option(Value, "usersBandwidthUp",
+    translate("Upload-Bandwidth in Mbit/s"))
+usersBandwidthUp.datatype = "float"
+usersBandwidthUp.rmempty = false
+
+-- "behind the scenes magic" to make the submit button do something
+main = f:option(DummyValue, "netconfig", "", "")
+main.forcewrite = true
+function main.parse(self, section)
+  local fvalue = "1"
+  if self.forcewrite then
+    self:write(section, fvalue)
+  end
+end
+-- end of "behind the scenes magic"
+
+-- write the new settings
+function main.write(self, section, value)
+  uci:set("ffwizard", "settings", "usersBandwidthUp", usersBandwidthUp:formvalue(section))
+  uci:set("ffwizard", "settings", "usersBandwidthDown", usersBandwidthDown:formvalue(section))
+
+  local up = usersBandwidthUp:formvalue(section) * 1000
+  local down = usersBandwidthDown:formvalue(section) * 1000
+
+  uci:set("qos", "ffuplink", "upload", up)
+  uci:set("qos", "ffuplink", "download", down)
+  local s = uci:get_first("olsrd", "olsrd")
+  uci:set("olsrd", s, "SmartGatewaySpeed", up.." "..down)
+
+  uci:save("ffwizard")
+  uci:save("qos")
+  uci:save("olsrd")
+  uci:commit("ffwizard")
+  uci:commit("qos")
+  uci:commit("olsrd")
+
+  -- Run the wizard again
+  luci.http.redirect(luci.dispatcher.build_url("admin/freifunk/assistent/startWizard"))
+end
+
+return f


### PR DESCRIPTION
Maintainer: me
Compile tested: none
Run tested: TP-Link WDR4900 V1
Description: allow the user to modify the bandwidth settings.

Fixes: #170
Signed-off-by: pmelange <isprotejesvalkata@gmail.com>
