### PR TITLE
ssid-changer: Add package ssid-changer

### DIFF
--- a/packages/falter-berlin-ssid-changer/Makefile
+++ b/packages/falter-berlin-ssid-changer/Makefile
@@ -1,0 +1,38 @@
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=falter-berlin-ssid-changer
+PKG_VERSION:=1
+
+include $(INCLUDE_DIR)/package.mk
+
+define Package/falter-berlin-ssid-changer
+  SECTION:=falter-berlin
+  CATEGORY:=falter-berlin
+  TITLE:=Freifunk Berlin ssid changer
+  URL:=http://github.com/Freifunk-Spalter/packages
+  PKGARCH:=all
+  EXTRA_DEPENDS:=pingcheck
+endef
+
+define Package/falter-berlin-ssid-changer/description
+  Scripts for changing the SSID of Freifunk-Routers when they go offline.
+endef
+
+define Build/Prepare
+	mkdir -p $(PKG_BUILD_DIR)
+endef
+
+define Build/Configure
+endef
+
+define Build/Compile
+endef
+
+define Package/falter-berlin-ssid-changer/install
+	$(INSTALL_DIR) $(1)/etc/pingcheck
+	$(CP) ./files/online.d $(1)/etc/pingcheck/online.d
+	$(CP) ./files/offline.d $(1)/etc/pingcheck/offline.d
+	$(CP) ./files/lib $(1)/lib
+endef
+
+$(eval $(call BuildPackage,falter-berlin-ssid-changer))

--- a/packages/falter-berlin-ssid-changer/files/lib/lib_ssid-changer.sh
+++ b/packages/falter-berlin-ssid-changer/files/lib/lib_ssid-changer.sh
@@ -1,0 +1,30 @@
+#/bin/sh
+. /lib/functions.sh
+
+NODENAME=$(uci_get system @system[-1] hostname | cut -b -24 ) # cut nodename to not exceed 32 bytes
+OFFLINE_SSID="offline_""$NODENAME"
+
+is_internet_reachable() {
+    # check if we really lost internet connection.
+    local ERROR=0
+    local DNS_SERVER="8.8.8.8 1.1.1.1 9.9.9.9"
+    for SERVER in $DNS_SERVER; do
+        ping -c1 $SERVER > /dev/null
+        if [ $? = 0 ]; then
+            return 0
+        fi
+    done
+    return 1
+}
+
+get_interfaces() {
+    # get the names of every interface named *dhcp* and fetch its normal ssid. Thus we get
+    # 2.4 and/or 5 GHz both
+    local IFACES=$(uci show wireless | grep -e "dhcp.*\.ssid='.*\.freifunk.net'" | cut -d'=' -f1 )
+    local ONLINE_SSIDS=""
+    for IFACE in $IFACES; do
+        local SSID=$(uci_get "$IFACE")
+        ONLINE_SSIDS="$SSID $ONLINE_SSIDS"
+    done
+    echo "$ONLINE_SSIDS"
+}

--- a/packages/falter-berlin-ssid-changer/files/offline.d/ssid-changer_isOffline.sh
+++ b/packages/falter-berlin-ssid-changer/files/offline.d/ssid-changer_isOffline.sh
@@ -1,0 +1,35 @@
+#!/bin/sh
+. /lib/functions.sh
+. /lib/lib_ssid-changer.sh
+
+# We do assume, that both radios (if there is more than one) share the same
+# SSID. Handling different SSIDS is too complicated.
+
+# leave the SSID as is, if there is still some connection to the net.
+[ "$GLOBAL" = "ONLINE" ] && exit
+
+is_internet_reachable
+[ $? = 0 ] && exit
+
+ONLINE_SSIDS=$(get_interfaces)
+LOGMSG="Didn't reach the internet. Change SSID to offline..."
+
+# abort if SSID is "offline" already
+for HOSTAPD in $(ls /var/run/hostapd-phy*); do
+    CURRSSID=$(grep -e "^ssid=" $HOSTAPD | cut -d'=' -f2)
+    if [ "$CURRSSID" = "$OFFLINE_SSID" ]; then
+        logger -s -t "ssid-changer" -p 5 "SSID offline already. Nothing to change."
+        exit 0
+    fi
+done
+
+# loop over hostapd configs and try to switch any matching ID.
+for HOSTAPD in $(ls /var/run/hostapd-phy*); do
+    for ONLINE_SSID in $ONLINE_SSIDS; do
+        logger -s -t "ssid-changer" -p 5 "$LOGMSG"
+        sed -i "s~^ssid=$ONLINE_SSID~ssid=$OFFLINE_SSID~" $HOSTAPD
+    done
+done
+
+# send hup to hostapd to reload ssid
+killall -HUP hostapd

--- a/packages/falter-berlin-ssid-changer/files/online.d/ssid-changer_isOnline.sh
+++ b/packages/falter-berlin-ssid-changer/files/online.d/ssid-changer_isOnline.sh
@@ -1,0 +1,35 @@
+#!/bin/sh
+. /lib/functions.sh
+. /lib/lib_ssid-changer.sh
+
+# We do assume, that both radios (if there is more than one) share the same
+# SSID. Handling different SSIDS is too complicated.
+
+# check, if we really went back online
+is_internet_reachable
+[ $? = 1 ] && exit
+
+
+ONLINE_SSIDS=$(get_interfaces)
+CHK_SSID=$(echo "$ONLINE_SSIDS" | cut -d' ' -f1) # makes checking easier
+LOGMSG="Internet reachable again. Change SSID back to online..."
+
+# abort if SSID is "online" already
+for HOSTAPD in $(ls /var/run/hostapd-phy*); do
+    CURRSSID=$(grep -e "^ssid=" $HOSTAPD | cut -d'=' -f2)
+    if [ "$CURRSSID" = "$CHK_SSID" ]; then
+        logger -s -t "ssid-changer" -p 5 "SSID online already. Nothing to change."
+        exit 0
+    fi
+done
+
+# loop over hostapd configs and try to switch any matching ID.
+for HOSTAPD in $(ls /var/run/hostapd-phy*); do
+    for ONLINE_SSID in $ONLINE_SSIDS; do
+        logger -s -t "ssid-changer" -p 5 "$LOGMSG"
+        sed -i "s~^ssid=$OFFLINE_SSID~ssid=$ONLINE_SSID~" $HOSTAPD
+    done
+done
+
+# send hup to hostapd to reload ssid
+killall -HUP hostapd


### PR DESCRIPTION
If one node hasn't got any connection to the internet it's
ssid gets changed to some string that says its offline.
It uses the pingcheck package for determining that.
This is intended for raising the user experience by avoiding
the broadcast of conectionless WiFis.

Signed-off-by: Martin Hübner <martin.hubner@web.de>

Maintainer: me / @\<github-user> (find it by checking history of the package Makefile)
Compile tested: (put here arch, model, OpenWrt version)
Run tested: (put here arch, model, OpenWrt version, tests done)

Description:

This would fix #4 