### PR TITLE
Mesh settings check for null

### DIFF
--- a/luci/luci-app-ffwizard-falter/luasrc/model/cbi/freifunk/upgrades/005-wireless-mesh.lua
+++ b/luci/luci-app-ffwizard-falter/luasrc/model/cbi/freifunk/upgrades/005-wireless-mesh.lua
@@ -86,6 +86,9 @@ function write_ffwizard(section)
   uci:foreach("wireless", "wifi-device",
     function(sec)
       local device = sec[".name"]
+      if wifi_tbl[device]["newmeshmode"] == nil then
+        return
+      end
       uci:set("ffwizard", "settings","meshmode_" .. device,
         wifi_tbl[device]["newmeshmode"]:formvalue(section))
     end)
@@ -103,6 +106,9 @@ function write_wireless(section)
       local mode = sec["mode"]
       local ifname = sec["ifname"]
       local device = sec["device"]
+      if wifi_tbl[device]["newmeshmode"] == nil then
+        return
+      end
       local network = sec["network"]
       local formvalue = wifi_tbl[device]["newmeshmode"]:formvalue(section)
       local newmeshmode = formvalue

--- a/luci/luci-mod-falter/luasrc/model/cbi/freifunk/wireless-mesh.lua
+++ b/luci/luci-mod-falter/luasrc/model/cbi/freifunk/wireless-mesh.lua
@@ -87,6 +87,9 @@ function write_ffwizard(section)
   uci:foreach("wireless", "wifi-device",
     function(sec)
       local device = sec[".name"]
+      if wifi_tbl[device]["newmeshmode"] == nil then
+        return
+      end
       uci:set("ffwizard", "settings","meshmode_" .. device,
         wifi_tbl[device]["newmeshmode"]:formvalue(section))
     end)
@@ -102,6 +105,9 @@ function write_wireless(section)
       local mode = sec["mode"]
       local ifname = sec["ifname"]
       local device = sec["device"]
+      if wifi_tbl[device]["newmeshmode"] == nil then
+        return
+      end
       local network = sec["network"]
       local formvalue = wifi_tbl[device]["newmeshmode"]:formvalue(section)
       local newmeshmode = formvalue


### PR DESCRIPTION
Maintainer: me
Run tested: (mpc85xx, wdr4900, falter 1.1.1, runtest)

Description: check for null on each wireless device, sanity check

If the user were to delete a wireless mesh interface or has a wireless
device which does not support either adhoc or 802.11s, then it can lead
to a situation where a null pointer is referenced.

Fixes: #177 