### PR TITLE
falter-berlin-migration: add migrations for 1.1.2

### DIFF
--- a/packages/falter-berlin-migration/uci-defaults/freifunk-berlin-01-migration.sh
+++ b/packages/falter-berlin-migration/uci-defaults/freifunk-berlin-01-migration.sh
@@ -661,6 +661,12 @@ r1_1_1_rssiled() {
   config_foreach handle_wifi_iface_rssiled wifi-iface
 }
 
+r1_1_2_bump_repo() {
+  # adjust the opkg packagefeed to point to new version
+  log "bumping packagefeed to 1.1.2"
+  sed -ie 's|firmware.berlin.freifunk.net/feed/.*/packages|firmware.berlin.freifunk.net/feed/1.1.2/packages|g' /etc/opkg/customfeeds.conf
+}
+
 migrate () {
   log "Migrating from ${OLD_VERSION} to ${VERSION}."
 
@@ -742,6 +748,10 @@ migrate () {
 
   if semverLT ${OLD_VERSION} "1.1.1"; then
     r1_1_1_rssiled
+  fi
+
+  if semverLT ${OLD_VERSION} "1.1.2"; then
+    r1_1_2_bump_repo
   fi
 
   # overwrite version with the new version


### PR DESCRIPTION
The file /etc/opkg/customfeed.conf gets preserved at sysupgrades.
Thus we need to migrate the feed url to point to the new falter
release.

Signed-off-by: Martin Hübner <martin.hubner@web.de>

Maintainer: me / @\<github-user> (find it by checking history of the package Makefile)
Compile tested: (put here arch, model, OpenWrt version)
Run tested: (put here arch, model, OpenWrt version, tests done)

Description:
This should be cherry-picked into 21.02 and 19.07 too. (please use -x option)