### PR TITLE
luci-app-falter-owm: use 127.0.0.1 instead of localhost

### DIFF
--- a/luci/luci-app-falter-owm/Makefile
+++ b/luci/luci-app-falter-owm/Makefile
@@ -8,7 +8,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=luci-app-falter-owm
-PKG_VERSION:=2020.11.15
+PKG_VERSION:=2021.09.03
 
 PKG_BUILD_DIR := $(BUILD_DIR)/$(PKG_NAME)
 PKG_BUILD_DEPENDS += lua/host luci-base/host LUCI_CSSTIDY:csstidy/host LUCI_SRCDIET:luasrcdiet/host $(LUCI_BUILD_DEPENDS)

--- a/luci/luci-app-falter-owm/files/owm.sh
+++ b/luci/luci-app-falter-owm/files/owm.sh
@@ -77,7 +77,7 @@ olsr6_links() {
 }
 
 # This section is relevant for hopglass statistics feature (isUplink/isHotspot)
-OLSRCONFIG=$(printf "/config" | nc localhost 9090)
+OLSRCONFIG=$(printf "/config" | nc 127.0.0.1 9090)
 
 # collect nodes location
 uci_load system


### PR DESCRIPTION
IPv6 becomes now first lookup. So localhost resolves to ::1. oslr is not listening on ::1 if you have not enabled olsrd6 which we don't use.
