### PR TITLE
falter-berlin-firewall-defaults: synflood_protect update

### DIFF
--- a/packages/falter-berlin-firewall-defaults/Makefile
+++ b/packages/falter-berlin-firewall-defaults/Makefile
@@ -1,7 +1,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=falter-berlin-firewall-defaults
-PKG_VERSION:=2
+PKG_VERSION:=3
 
 include $(INCLUDE_DIR)/package.mk
 

--- a/packages/falter-berlin-firewall-defaults/uci-defaults/freifunk-berlin-firewall-defaults
+++ b/packages/falter-berlin-firewall-defaults/uci-defaults/freifunk-berlin-firewall-defaults
@@ -8,7 +8,7 @@ uci import firewall <<EOF
 EOF
 
 SECTION="$(uci add firewall defaults)"
-uci set firewall.$SECTION.syn_flood=1
+uci set firewall.$SECTION.synflood_protect=1
 uci set firewall.$SECTION.input=ACCEPT
 uci set firewall.$SECTION.output=ACCEPT
 uci set firewall.$SECTION.forward=REJECT


### PR DESCRIPTION
According to the OpenWRT documentation
(https://openwrt.org/docs/guide-user/firewall/firewall_configuration)
syn_flood is depricated and should be replaced using synflood_protect.

Fixes: #178
Signed-off-by: pmelange <isprotejesvalkata@gmail.com>
