### PR TITLE
falter-berlin-migration: updates for openwrt 21.02.0

### DIFF
--- a/packages/falter-berlin-migration/Makefile
+++ b/packages/falter-berlin-migration/Makefile
@@ -1,7 +1,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=falter-berlin-migration
-PKG_VERSION:=4
+PKG_VERSION:=5
 
 PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)
 


### PR DESCRIPTION
Newly added migration functions include:
ensure_profiled
r1_2_0_dhcp
r1_2_0_fw_zone_freifunk
r1_2_0_fw_synflood
r1_2_0_statistics
r1_2_0_network
r1_2_0_olsrd
r1_2_0_owm
r1_2_0_dynbanner

Fixes: #215
Fixes: #214
Fixes: #211
Fixes: #178
Signed-off-by: pmelange <isprotejesvalkata@gmail.com>
