### PR TITLE
change firewall zone device from option to list

### DIFF
--- a/packages/falter-berlin-firewall-defaults/uci-defaults/freifunk-berlin-firewall-defaults
+++ b/packages/falter-berlin-firewall-defaults/uci-defaults/freifunk-berlin-firewall-defaults
@@ -81,7 +81,7 @@ uci set firewall.zone_freifunk.forward=REJECT
 uci set firewall.zone_freifunk.name=freifunk
 uci set firewall.zone_freifunk.output=ACCEPT
 uci add_list firewall.zone_freifunk.network=tunl0
-uci set firewall.zone_freifunk.device=tnl_+
+uci add_list firewall.zone_freifunk.device=tnl_+
 
 # add named zone section for the uplink of client-traffic
 uci set firewall.zone_ffuplink=zone

--- a/packages/falter-berlin-migration/uci-defaults/freifunk-berlin-01-migration.sh
+++ b/packages/falter-berlin-migration/uci-defaults/freifunk-berlin-01-migration.sh
@@ -728,6 +728,12 @@ r1_2_0_fw_zone_freifunk() {
   for net in $NETS; do
     uci add_list firewall.zone_freifunk.network=$net
   done
+  DEVS=$(uci -q get firewall.zone_freifunk.device)
+  uci delete firewall.zone_freifunk.device
+  for dev in $DEVS; do
+    uci add_list firewall.zone_freifunk.device=$dev
+  done
+
   uci commit firewall
 }
 


### PR DESCRIPTION
using the device option in a firewall zone is deprecated, and instead is made as a list.

There is no need to bump the pkgver since this commit is basically back-to-back with d0e572d

Fixes: #223
