### PR TITLE
1.1.3 migration bbbdigger typo

### DIFF
--- a/packages/falter-berlin-migration/uci-defaults/freifunk-berlin-01-migration.sh
+++ b/packages/falter-berlin-migration/uci-defaults/freifunk-berlin-01-migration.sh
@@ -705,6 +705,21 @@ r1_1_2_rssiled() {
   r1_1_1_rssiled
 }
 
+r1_1_3_fixbbbdigger() {
+  handle_device() {
+    local config=$1
+    local name=$(uci get network.$config.name)
+    if [ $name = "bbbdiggger" ]; then
+      log "fixing misspelling of bbbdigger device section"
+      uci set network.$config.name=bbbdigger
+      uci commit network
+    fi
+  }
+  reset_cb
+  config_load network
+  config_foreach handle_device device
+}
+
 migrate () {
   log "Migrating from ${OLD_VERSION} to ${VERSION}."
 
@@ -796,6 +811,9 @@ migrate () {
     r1_1_2_rssiled
   fi
 
+  if semverLT ${OLD_VERSION} "1.1.3"; then
+    r1_1_3_fixbbbdigger
+  fi
 
   # overwrite version with the new version
   log "Setting new system version to ${VERSION}."


### PR DESCRIPTION
Add migration for bbbdigger typo

Fix the typo from previous versions
Bug introduced in 9ab7a8595ec24315de2112ffed439797a16d934b
and fixed in f38bc2b6e0a7691a84be9115603cb2a7e5b1be0e

Fixes: #232
Signed-off-by: pmelange <isprotejesvalkata@gmail.com>