### PR TITLE
luci-mod-falter: fix confusing wording

### DIFF
--- a/luci/luci-mod-falter/luasrc/model/cbi/freifunk/basics.lua
+++ b/luci/luci-mod-falter/luasrc/model/cbi/freifunk/basics.lua
@@ -8,7 +8,7 @@ local uci = require "luci.model.uci".cursor()
 local profiles = "/etc/config/profile_*"
 
 m = Map("freifunk", translate ("Community"))
-c = m:section(NamedSection, "community", "public", nil, translate("These are the basic settings for your local wireless community. These settings define the default values for the wizard and DO NOT affect the actual configuration of the router."))
+c = m:section(NamedSection, "community", "public", nil, translate("The community profile holds the basic settings for your local wireless community. These settings define the default values for the wizard. Changing the community profile DOES NOT affect the actual configuration of the router. Please do another wizard run or adjust the values by hand."))
 
 community = c:option(ListValue, "name", translate ("Community"))
 community.rmempty = false

--- a/luci/luci-mod-falter/po/de/falter.po
+++ b/luci/luci-mod-falter/po/de/falter.po
@@ -520,6 +520,19 @@ msgstr ""
 "Positionsdaten aus dem Netzwerk.<br /> Bitte stelle sicher, dass Nameservice-"
 "Plugin korrekt ist und das die Option <em>latlon_file</em> eingeschaltet ist."
 
+#: luci/luci-mod-falter/luasrc/model/cbi/freifunk/basics.lua:11
+msgid ""
+"The community profile holds the basic settings for your local wireless "
+"community. These settings define the default values for the wizard. Changing "
+"the community profile DOES NOT affect the actual configuration of the "
+"router. Please do another wizard run or adjust the values by hand."
+msgstr ""
+"Das Community-Profil beinhaltet die Grundeinstellungen für deine lokale "
+"Community. Diese Einstellungen beeinflussen die Standard-Werte im Wizard. "
+"Das Community-Profil zu wechseln, ändert NICHT die aktuellen Einstellungen "
+"an deinem Router. Bitte führe dafür den Wizard nochmals aus oder passe die "
+"Einstellungen von Hand an."
+
 #: luci/luci-mod-falter/luasrc/model/cbi/freifunk/bandwidth.lua:7
 msgid ""
 "The nodes of the Freifunk network foward data based on shortest paths and "
@@ -557,16 +570,6 @@ msgstr ""
 "zu Verbindungsverlusten führen. Bitte wende dich an deine Mesh-Nachbarn, um "
 "gemeinsam zu 802.11s zu wechseln. Bitte wähle aus, welches Protokoll "
 "verwendet werden soll."
-
-#: luci/luci-mod-falter/luasrc/model/cbi/freifunk/basics.lua:11
-msgid ""
-"These are the basic settings for your local wireless community. These "
-"settings define the default values for the wizard and DO NOT affect the "
-"actual configuration of the router."
-msgstr ""
-"Dies sind die Grundeinstellungen für deine lokale Freifunk-Community. Sie "
-"definieren die Standard des Wizards und verändern die aktuellen "
-"Routereinstellungen NICHT."
 
 #: luci/luci-mod-falter/luasrc/model/cbi/freifunk/profile.lua:13
 msgid "These are the settings of your local community."
@@ -718,3 +721,12 @@ msgstr "benutzt"
 #: luci/luci-mod-falter/luasrc/view/freifunk/adminindex.htm:39
 msgid "wireless settings"
 msgstr "WLAN-Einstellungen"
+
+#~ msgid ""
+#~ "These are the basic settings for your local wireless community. These "
+#~ "settings define the default values for the wizard and DO NOT affect the "
+#~ "actual configuration of the router."
+#~ msgstr ""
+#~ "Dies sind die Grundeinstellungen für deine lokale Freifunk-Community. Sie "
+#~ "definieren die Standard des Wizards und verändern die aktuellen "
+#~ "Routereinstellungen NICHT."

--- a/luci/luci-mod-falter/po/en/falter.po
+++ b/luci/luci-mod-falter/po/en/falter.po
@@ -12,6 +12,7 @@ msgstr ""
 "X-Generator: Poedit 2.4.2\n"
 "Language-Team: \n"
 
+
 #: luci/luci-mod-falter/luasrc/model/cbi/freifunk/wireless-mesh.lua:46
 msgid ""
 "</strong>. The current default setup is 802.11s. Please select how to use "
@@ -489,6 +490,14 @@ msgid ""
 "configured and that the <em>latlon_file</em> option is enabled."
 msgstr ""
 
+#: luci/luci-mod-falter/luasrc/model/cbi/freifunk/basics.lua:11
+msgid ""
+"The community profile holds the basic settings for your local wireless "
+"community. These settings define the default values for the wizard. Changing "
+"the community profile DOES NOT affect the actual configuration of the "
+"router. Please do another wizard run or adjust the values by hand."
+msgstr ""
+
 #: luci/luci-mod-falter/luasrc/model/cbi/freifunk/bandwidth.lua:7
 msgid ""
 "The nodes of the Freifunk network foward data based on shortest paths and "
@@ -509,13 +518,6 @@ msgid ""
 "standard. Also, if this router currently meshes with Ad-Hoc then changing it "
 "to 802.11s would cause connectivity loss. Please contact your mesh neighbors "
 "to switch to 802.11s collectively. Please select which protocol to use."
-msgstr ""
-
-#: luci/luci-mod-falter/luasrc/model/cbi/freifunk/basics.lua:11
-msgid ""
-"These are the basic settings for your local wireless community. These "
-"settings define the default values for the wizard and DO NOT affect the "
-"actual configuration of the router."
 msgstr ""
 
 #: luci/luci-mod-falter/luasrc/model/cbi/freifunk/profile.lua:13

--- a/luci/luci-mod-falter/po/templates/falter.pot
+++ b/luci/luci-mod-falter/po/templates/falter.pot
@@ -478,6 +478,14 @@ msgid ""
 "configured and that the <em>latlon_file</em> option is enabled."
 msgstr ""
 
+#: luci/luci-mod-falter/luasrc/model/cbi/freifunk/basics.lua:11
+msgid ""
+"The community profile holds the basic settings for your local wireless "
+"community. These settings define the default values for the wizard. Changing "
+"the community profile DOES NOT affect the actual configuration of the "
+"router. Please do another wizard run or adjust the values by hand."
+msgstr ""
+
 #: luci/luci-mod-falter/luasrc/model/cbi/freifunk/bandwidth.lua:7
 msgid ""
 "The nodes of the Freifunk network foward data based on shortest paths and "
@@ -498,13 +506,6 @@ msgid ""
 "standard. Also, if this router currently meshes with Ad-Hoc then changing it "
 "to 802.11s would cause connectivity loss. Please contact your mesh neighbors "
 "to switch to 802.11s collectively. Please select which protocol to use."
-msgstr ""
-
-#: luci/luci-mod-falter/luasrc/model/cbi/freifunk/basics.lua:11
-msgid ""
-"These are the basic settings for your local wireless community. These "
-"settings define the default values for the wizard and DO NOT affect the "
-"actual configuration of the router."
 msgstr ""
 
 #: luci/luci-mod-falter/luasrc/model/cbi/freifunk/profile.lua:13


### PR DESCRIPTION
The text on changing community-profiles was misunderstood
by some users. This introduces a better wording.

Fixes: #199

Signed-off-by: Martin Hübner <martin.hubner@web.de>

please cherry-pick to 21.02 and 19.07