### PR TITLE
Add DNS SRV support to tunneldigger, improve init script

### DIFF
--- a/packages/falter-berlin-tunneldigger/Makefile
+++ b/packages/falter-berlin-tunneldigger/Makefile
@@ -2,7 +2,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=falter-berlin-tunneldigger
 PKG_SOURCE_DATE:=2020-08-10
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_URL:=https://github.com/wlanslovenija/tunneldigger.git

--- a/packages/falter-berlin-tunneldigger/files/tunneldigger.hotplug
+++ b/packages/falter-berlin-tunneldigger/files/tunneldigger.hotplug
@@ -24,6 +24,26 @@ interface_disabled() {
         echo "${disabled}"
 }
 
+srv_lookup() {
+        local srv="$1"
+        local i
+        local srvlist=""
+        for i in $srv; do
+                local lookup=$(nslookup -q=SRV $i | grep $i | cut -d "=" -f 2)
+                local OLDIFS=$IFS
+                IFS=$'\n'
+                local j
+                for j in $lookup; do
+                        local host=$(echo $j | cut -d ' ' -f 5)
+                        local port=$(echo $j | cut -d ' ' -f 4)
+                        append srvlist "${host}:${port}"
+                done
+                IFS=$OLDIFS
+        done
+
+        echo "${srvlist}"
+}
+
 missing() {
         logger -t td-client "Not starting tunneldigger \"$1\" - missing $2" >&2
 }
@@ -31,6 +51,7 @@ missing() {
 handle_td_ifup() {
         local cfg=$1
         local enabled
+        local srv
         local addresses
         local uuid
         local interface
@@ -41,6 +62,7 @@ handle_td_ifup() {
         local broker_selection
 
         config_get_bool enabled "$cfg" enabled 1
+        config_get srv "$cfg" srv
         config_get addresses "$cfg" address
         config_get uuid "$cfg" uuid
         config_get interface "$cfg" interface
@@ -61,8 +83,16 @@ handle_td_ifup() {
         [ $(tunnel_is_up ${interface}) == "1" ] && return
 
         local broker_opts=""
+
+        # use addresses provided by srv before the addresses list
+        # in most circumstances, only an srv entry should be found
+        # or a list of addresses.  Here, we handle both.
+        srvlist=$(srv_lookup "$srv")
         local address
-        for address in $addresses; do
+        local count=0
+        for address in $srvlist $addresses; do
+                count=$(($count+1))
+                [ $count -gt 10 ] && break # limit of 10 addresses
                 append broker_opts "-b ${address}"
         done
 

--- a/packages/falter-berlin-tunneldigger/files/tunneldigger.init
+++ b/packages/falter-berlin-tunneldigger/files/tunneldigger.init
@@ -53,7 +53,24 @@ missing() {
 }
 
 handle_td() {
-        local cfg=$1
+        local cfg=$1; shift
+        # determine if we should start only this instance
+        local sections=$@
+        local argn=$#
+        local skip=0
+        if [ $argn -ne 0 ]; then
+                skip=1
+                for section in $sections; do
+                        if [ "$cfg" == "$section" ]; then
+                                skip=0
+                                break
+                        fi
+                done
+                if [ $skip -ne 0 ]; then
+                        return
+                fi
+        fi
+
         local enabled
         local srv
         local addresses
@@ -127,15 +144,38 @@ handle_td() {
         /sbin/start-stop-daemon -S -q -b -m -c root:${group} -p ${PIDPATH}/tunneldigger.${interface}.pid -x /usr/bin/tunneldigger -- -u ${uuid} -i ${interface} -t ${tunnel_id} ${broker_opts}
 }
 
+# the start function can take arguements.  Without any arguements, the default behavior is
+# to start all tunneldigger sections.  With arguements, only the listed tunneldigger
+# sections are started
 start() {
         config_load tunneldigger
-        config_foreach handle_td broker
+        config_foreach handle_td broker $@
 }
 
+# the stop function can take arguements.  Without any arguements, the default behavior is
+# to stop all tunneldigger sections.  With arguements, only the listed tunneldigger
+# sections are stopped
 stop() {
+        local sections=$@
+        local argn=$#
         for PIDFILE in `find ${PIDPATH}/ -name "tunneldigger\.*\.pid"`; do
                 PID="$(cat ${PIDFILE})"
                 IFACE="$(echo ${PIDFILE} | awk -F\/tunneldigger '{print $2}' | cut -d'.' -f2)"
+                # determine if we should stop only this instance
+                local skip=0
+                if [ $argn -ne 0 ]; then
+                        skip=1
+                        for section in $sections; do
+                                local section_iface=$(uci get tunneldigger.${section}.interface)
+                                if [ $IFACE = $section_iface ]; then
+                                        skip=0
+                                        break
+                                fi
+                         done
+                         if [ $skip -ne 0 ]; then
+                                continue
+                         fi
+                fi
                 echo "Stopping tunneldigger for interface ${IFACE}"
                 start-stop-daemon -K -q -p $PIDFILE 
                 while test -d "/proc/${PID}"; do
@@ -147,8 +187,11 @@ stop() {
         done
 }
 
+# the restart function can take arguements.  Without any arguements, the default behavior is
+# to restart all tunneldigger sections.  With arguements, only the listed tunneldigger
+# sections are restarted
 restart() {
-        stop
-        start
+        stop $@
+        start $@
 }
 

--- a/packages/falter-berlin-tunneldigger/files/tunneldigger.init
+++ b/packages/falter-berlin-tunneldigger/files/tunneldigger.init
@@ -28,6 +28,26 @@ interface_disabled() {
         echo "${disabled}"
 }
  
+srv_lookup() {
+        local srv="$1"
+        local i
+        local srvlist=""
+        for i in $srv; do
+                local lookup=$(nslookup -q=SRV $i | grep $i | cut -d "=" -f 2)
+                local OLDIFS=$IFS
+                IFS=$'\n'
+                local j
+                for j in $lookup; do
+                        local host=$(echo $j | cut -d ' ' -f 5)
+                        local port=$(echo $j | cut -d ' ' -f 4)
+                        append srvlist "${host}:${port}"
+                done
+                IFS=$OLDIFS
+        done
+
+        echo "${srvlist}"
+}
+
 missing() {
         echo "Not starting tunneldigger \"$1\" - missing $2" >&2
 }
@@ -35,6 +55,7 @@ missing() {
 handle_td() {
         local cfg=$1
         local enabled
+        local srv
         local addresses
         local uuid
         local interface
@@ -45,6 +66,7 @@ handle_td() {
         local broker_selection
 
         config_get_bool enabled "$cfg" enabled 1
+        config_get srv "$cfg" srv
         config_get addresses "$cfg" address
         config_get uuid "$cfg" uuid
         config_get interface "$cfg" interface
@@ -63,8 +85,16 @@ handle_td() {
                 echo "Not starting tunneldigger \"${cfg}\", already started" && return
 
         local broker_opts=""
+
+        # use addresses provided by srv before the addresses list
+        # in most circumstances, only an srv entry should be found
+        # or a list of addresses.  Here, we handle both.
+        srvlist=$(srv_lookup "$srv")
         local address
-        for address in $addresses; do
+        local count=0
+        for address in $srvlist $addresses; do
+                count=$(($count+1))
+                [ $count -gt 10 ] && break # limit of 10 addresses
                 append broker_opts "-b ${address}"
         done
 


### PR DESCRIPTION
Add support for option srv to /etc/config/tunneldigger, which denotes an SRV DNS entry.  This can be used instead or with the address list.  The advantage of using an srv, is that only on the dns server side do we need to modify the list as servers are added/removed.

Add optional to the init script.  The start, stop and restart function can take arguements.  Without any arguements, the default behavior is to start/stop/restart all tunneldigger sections.  With arguements, only the listed tunneldigger sections are started/stopped/restarted

Fixes #220 