### PR TITLE
Move tunneldigger configs to srv

### DIFF
--- a/luci/luci-mod-falter/Makefile
+++ b/luci/luci-mod-falter/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 LUCI_TITLE:=Freifunk Public and Admin LuCI UI
 LUCI_EXTRA_DEPENDS:=luci-mod-admin-full, luci-lib-json, falter-profiles, luci-lib-ipkg, luci-compat
-PKG_RELEASE:=6
+PKG_RELEASE:=7
 
 include ../include-luci.mk
 

--- a/luci/luci-mod-falter/luasrc/model/cbi/freifunk/bbbdigger.lua
+++ b/luci/luci-mod-falter/luasrc/model/cbi/freifunk/bbbdigger.lua
@@ -81,9 +81,7 @@ function main.write(self, section, value)
         uuid = uuid .. sys.exec("dd if=/dev/urandom bs=1 count=1 2> /dev/null | hexdump -e '1/1 \":%02x\"'")
       end
       uci:set("tunneldigger", "bbbdigger", "broker")
-      uci:set("tunneldigger", "bbbdigger", "address", { 
-        "a.bbb-vpn.berlin.freifunk.net:8942", 
-        "b.bbb-vpn.berlin.freifunk.net:8942" } )
+      uci:set("tunneldigger", "bbbdigger", "srv", "_bbb-vpn._udp.berlin.freifunk.net")
       uci:set("tunneldigger", "bbbdigger", "uuid", uuid)
       uci:set("tunneldigger", "bbbdigger", "interface", "bbbdigger")
       uci:set("tunneldigger", "bbbdigger", "broker_selection", "usage")
@@ -111,7 +109,7 @@ function main.write(self, section, value)
     uci:commit("tunneldigger")
     uci:commit("firewall")
     uci:commit("olsrd")
-    sys.exec("/etc/init.d/tunneldigger restart")
+    sys.exec("/etc/init.d/tunneldigger restart bbbdigger")
 
   end
 

--- a/packages/falter-berlin-bbbdigger/Makefile
+++ b/packages/falter-berlin-bbbdigger/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=falter-berlin-bbbdigger
 PKG_VERSION:=0.0.3
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)
 

--- a/packages/falter-berlin-bbbdigger/files/postinst.sh
+++ b/packages/falter-berlin-bbbdigger/files/postinst.sh
@@ -10,7 +10,7 @@
 
 . /lib/functions.sh
 
-TUNNEL_SERV='a.bbb-vpn.berlin.freifunk.net:8942 b.bbb-vpn.berlin.freifunk.net:8942'
+TUNNEL_SRV='_bbb-vpn._udp.berlin.freifunk.net'
 IFACE=bbbdigger
 BIND=wan
 
@@ -35,10 +35,9 @@ fi
 
 # tunneldigger setup
 uci set tunneldigger.$IFACE=broker
+# remove old address list in favor of srv
 uci -q delete tunneldigger.$IFACE.address
-for srv in $TUNNEL_SERV; do
-  uci add_list tunneldigger.$IFACE.address=$srv
-done
+uci set tunneldigger.$IFACE.srv=$TUNNEL_SRV
 uci set tunneldigger.$IFACE.uuid=$UUID
 uci set tunneldigger.$IFACE.interface=$IFACE
 uci set tunneldigger.$IFACE.broker_selection=usage

--- a/packages/falter-berlin-migration/Makefile
+++ b/packages/falter-berlin-migration/Makefile
@@ -1,7 +1,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=falter-berlin-migration
-PKG_VERSION:=5
+PKG_VERSION:=6
 
 PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)
 

--- a/packages/falter-berlin-migration/uci-defaults/freifunk-berlin-01-migration.sh
+++ b/packages/falter-berlin-migration/uci-defaults/freifunk-berlin-01-migration.sh
@@ -916,6 +916,20 @@ r1_2_0_fixbbbdigger() {
   config_foreach handle_device device
 }
 
+r1_2_0_tunneldigger_srv() {
+  local section=$1
+  local srv=$2
+  # check to make sure such a section is defined
+  uci -q get tunneldigger.${section}
+  if [ $? -ne 0 ]; then
+    log "updating server list for $section"
+    uci -q delete tunneldigger.${section}.address
+    uci -q set tunneldigger.${section}.srv="$srv"
+    uci commit tunneldigger
+    /etc/init.d/tunneldigger restart $section
+  fi
+}
+
 migrate () {
   log "Migrating from ${OLD_VERSION} to ${VERSION}."
 
@@ -1018,6 +1032,8 @@ migrate () {
     r1_2_0_owm
     r1_2_0_dynbanner
     r1_2_0_fixbbbdigger
+    r1_2_0_tunneldigger_srv "ffuplink" "_tunnel._udp.berlin.freifunk.net"
+    r1_2_0_tunneldigger_srv "bbbdigger" "_bbb-vpn._udp.berlin.freifunk.net"
   fi
 
   # overwrite version with the new version

--- a/packages/falter-berlin-uplink-tunnelberlin/Makefile
+++ b/packages/falter-berlin-uplink-tunnelberlin/Makefile
@@ -1,7 +1,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=falter-berlin-uplink-tunnelberlin
-PKG_VERSION:=1
+PKG_VERSION:=2
 
 include $(INCLUDE_DIR)/package.mk
 

--- a/packages/falter-berlin-uplink-tunnelberlin/uci-defaults/freifunk-berlin-z95_tunnelberlin-tunneldigger
+++ b/packages/falter-berlin-uplink-tunnelberlin/uci-defaults/freifunk-berlin-z95_tunnelberlin-tunneldigger
@@ -55,10 +55,9 @@ fi
 
 uci delete tunneldigger.ffuplink
 uci set tunneldigger.ffuplink=broker
+# Remove old address list in excahange with srv
 uci -q delete tunneldigger.ffuplink.address
-for srv in a b c d e f; do
-  uci add_list tunneldigger.ffuplink.address=$srv.tunnel.berlin.freifunk.net:8942
-done
+uci set tunneldigger.ffuplink.srv='_tunnel._udp.berlin.freifunk.net'
 uci set tunneldigger.ffuplink.uuid=$UUID
 uci set tunneldigger.ffuplink.interface=ffuplink
 uci set tunneldigger.ffuplink.broker_selection=usage


### PR DESCRIPTION
Migrate all tunneldigger sections from address list to srv option.

This has been possible since commit 29943b0