### PR TITLE
CONTRIBUTING.md: add contribution guideline

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,66 @@
+# Contributing to Falter
+We love your input! We want to make contributing to this project as easy and transparent as possible, whether it's:
+
+- Reporting a bug
+- Discussing the current state of the code
+- Submitting a fix
+- Proposing new features
+- Becoming a maintainer
+
+## We Develop with Github
+We use github to host code, to track issues and feature requests, as well as accept pull requests.
+
+## We Use GitHub, So All Code Changes Happen Through Pull Requests
+Pull requests are the best way to propose changes to the codebase. We actively welcome your pull requests:
+
+1. Fork the repo and create your branch from `master`.
+2. If you've added code that should be tested, test it and describe your tests in the PR.
+3. Make sure your code lints (it has correct syntax).
+4. Make sure that every commit in your PR matches the formal requirements (see below).
+5. Issue that pull request!
+
+### Requirements on commits
+Please make sure, that every commit you make to this repository meets this requirements. They get checked by our CI:
+
+```txt
+$PACKAGE_NAME: one-line-description of your changes
+
+More detailed description of your changes. This part might be
+as long and detailed as you wish.
+
+Signed-off-by: $YOUR_SIGNATURE
+```
+You can add the signed-off-by line automatically via `git commit -s`. 
+
+## Any contributions you make will be under the GPLv3 Software License
+In short, when you submit code changes, your submissions are understood to be under the same [GPLv3 License](http://www.gnu.org/licenses/gpl-3.0.html) that covers the project. Feel free to contact the maintainers if that's a concern.
+
+## Report bugs using Github's [issues](https://github.com/Freifunk-Spalter/packages/issues)
+We use GitHub issues to track public bugs. Report a bug by [opening a new issue](https://github.com/Freifunk-Spalter/packages/issues/new); it's that easy!
+
+## Write bug reports with detail, background, and sample code
+A good bug report helps the maintainers a lot to understand you problem and fix it faster.
+
+**Great Bug Reports** tend to have:
+
+- A quick summary and/or background
+- Steps to reproduce
+  - Be specific!
+  - Give sample code if you can.
+- What you expected would happen
+- What actually happens
+- Notes (possibly including why you think this might be happening, or stuff you tried that didn't work)
+
+People *love* thorough bug reports. I'm not even kidding.
+
+## Use a Consistent Coding Style
+As the code in this repository originates from several sources, some reaching back up to 2005 or so, we aren't too strict on coding style:
+
+1. Use spaces instead of tabs, please.
+2. keep consistent within your contribution or the package.
+
+## License
+By contributing, you agree that your contributions will be licensed under its GPLv3 License.
+
+## References
+This document was derived from a [github-gist](https://gist.github.com/briandk/3d2e8b3ec8daf5a27a62)


### PR DESCRIPTION
This commit adds a contribution guideline. This is a preparation
for hacktoberfest.

Signed-off-by: Martin Hübner <martin.hubner@web.de>

Maintainer: me / @\<github-user> (find it by checking history of the package Makefile)
Compile tested: (put here arch, model, OpenWrt version)
Run tested: (put here arch, model, OpenWrt version, tests done)

Description:
