### PR TITLE
luci-mod-falter: fix translation string "Sptzname"

### DIFF
--- a/luci/luci-mod-falter/Makefile
+++ b/luci/luci-mod-falter/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 LUCI_TITLE:=Freifunk Public and Admin LuCI UI
 LUCI_EXTRA_DEPENDS:=luci-mod-admin-full, luci-lib-json, falter-profiles, luci-lib-ipkg, luci-compat
-PKG_RELEASE:=7
+PKG_RELEASE:=8
 
 include ../include-luci.mk
 

--- a/luci/luci-mod-falter/po/de/falter.po
+++ b/luci/luci-mod-falter/po/de/falter.po
@@ -337,7 +337,7 @@ msgstr "Netzwerk für Client-DHCP Adressen"
 #: luci/luci-mod-falter/luasrc/model/cbi/freifunk/contact.lua:9
 #: luci/luci-mod-falter/luasrc/view/freifunk/contact.htm:28
 msgid "Nickname"
-msgstr "Sptzname"
+msgstr "Spitzname"
 
 #: luci/luci-mod-falter/luasrc/view/freifunk/public_status.htm:329
 msgid "No default routes known."


### PR DESCRIPTION
Fix a type in the translation for luci-mod-falter:
"Sptzname" -> "Spitzname"

Fixes: #252
Signed-off-by: pmelange <isprotejesvalkata@gmail.com>
