### PR TITLE
falter-berlin-migration: finish migration for 1.2.0

### DIFF
--- a/packages/falter-berlin-migration/Makefile
+++ b/packages/falter-berlin-migration/Makefile
@@ -1,7 +1,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=falter-berlin-migration
-PKG_VERSION:=6
+PKG_VERSION:=7
 
 PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)
 


### PR DESCRIPTION
Modified the firewall zone routine to migrate all zone

Updated the statistics routine to set enable to the same
value as luci_statistics.collectd_interface.enable so that
there is consistancy across nodes which have statistics
enabled or disabled

Fixes #248
Signed-off-by: pmelange <isprotejesvalkata@gmail.com>

