### PR TITLE
falter-berlin-migration: fix section name of loopback device

### DIFF
--- a/packages/falter-berlin-migration/uci-defaults/freifunk-berlin-01-migration.sh
+++ b/packages/falter-berlin-migration/uci-defaults/freifunk-berlin-01-migration.sh
@@ -842,12 +842,12 @@ r1_2_0_network() {
     uci -q delete network.dhcp.type
   fi
 
-  # change lo from ifname to device
-  dev=$(uci -q get network.lo.ifname)
+  # change loopback from ifname to device
+  dev=$(uci -q get network.loopback.ifname)
   if [ $? -eq 0 ]; then
-    log "changing lo interface from ifname sytax to device"
-    uci -q delete network.lo.ifname
-    uci -q set network.lo.device=$dev
+    log "changing loopback interface from ifname sytax to device"
+    uci -q delete network.loopback.ifname
+    uci -q set network.loopback.device=$dev
   fi
 
   # change tunl0 from ifname to device


### PR DESCRIPTION
use the correct name of the loopback section

Signed-off-by: pmelange <isprotejesvalkata@gmail.com>

