### PR TITLE
falter-berlin-autoupdate-keys: remove auto updatekey

### DIFF
--- a/packages/falter-berlin-autoupdate/keys/alex.pub
+++ b/packages/falter-berlin-autoupdate/keys/alex.pub
@@ -1,2 +1,0 @@
-untrusted comment: a2sc <fffalter@a2sc.eu>
-RWRLxFONXFgew/lT1wtgur4LZ48K1XxeBYPzfEp7jnnJOQk339s/+gEz


### PR DESCRIPTION
Removed autoupdate key from user "alex".

Signed-off-by: Tobias Schwarz <Noki@users.noreply.github.com>