### PR TITLE
falter-bird-utils: add UCI-to-Bird2 configuration translator

### DIFF
--- a/net/falter-bird-utils/Makefile
+++ b/net/falter-bird-utils/Makefile
@@ -1,0 +1,31 @@
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=falter-bird-utils
+PKG_VERSION:=1.0.0
+PKG_RELEASE:=1
+PKG_MAINTAINER:=Aditya Chooramani - adityaxchooramani@gmail.com
+
+include $(INCLUDE_DIR)/package.mk
+
+define Package/falter-bird-utils
+  SECTION:=net
+  CATEGORY:=Network
+  TITLE:=UCI-to-Bird2 Translator for Falter
+  DEPENDS:=+bird2 +ip-full
+endef
+
+define Package/falter-bird-utils/description
+  Automates Bird2 configuration for Falter Mesh Nodes using UCI.
+endef
+
+define Build/Compile
+endef
+
+define Package/falter-bird-utils/install
+	$(INSTALL_DIR) $(1)/etc/init.d
+	$(INSTALL_BIN) ./files/bird.init $(1)/etc/init.d/bird
+	$(INSTALL_DIR) $(1)/etc/config
+	$(INSTALL_DATA) ./files/bird.config $(1)/etc/config/bird
+endef
+
+$(eval $(call BuildPackage,falter-bird-utils))

--- a/net/falter-bird-utils/README.md
+++ b/net/falter-bird-utils/README.md
@@ -1,0 +1,12 @@
+# falter-bird-utils
+
+This package provides a UCI-to-Bird2 configuration translator for Falter mesh nodes.
+
+## Features
+- **Procd Integration:** Automatically regenerates Bird2 config and reloads the daemon on UCI changes.
+- **Dynamic Router ID:** Automatically detects the primary IPv4 address (e.g., from `br-lan`).
+- **Memory Optimized:** Writes configuration to `/var/etc` to protect flash storage.
+- **Link-Local Support:** Handles IPv6 interface scoping for BGP neighbors.
+
+## UCI Configuration
+The configuration is managed via `/etc/config/bird`.

--- a/net/falter-bird-utils/files/bird.config
+++ b/net/falter-bird-utils/files/bird.config
@@ -1,0 +1,9 @@
+config global 'global'
+    option local_as '65001'
+
+config bgp_peer 'my_backbone'
+    option address 'fe80::1'
+    option remote_as '65000'
+    option interface 'eth0'
+    option import_filter 'all'
+    option export_filter 'all'

--- a/net/falter-bird-utils/files/bird.init
+++ b/net/falter-bird-utils/files/bird.init
@@ -1,0 +1,82 @@
+#!/bin/sh /etc/rc.common
+
+USE_PROCD=1
+START=70
+STOP=10
+
+BIRD_BIN="/usr/sbin/bird"
+BIRD_CONF="/var/etc/bird.conf"
+BIRD_PID_FILE="/var/run/bird.pid"
+
+. /lib/functions.sh
+
+write_header() {
+    local as_num r_id
+    
+    config_load bird
+    
+    # Universal IP detection: Finds first global IPv4 that isn't loopback
+    r_id=$(ip -4 addr show | grep inet | grep -v '127.0.0.1' | awk '{print $2}' | cut -d/ -f1 | head -n1)
+    [ -z "$r_id" ] && r_id="1.1.1.1"
+
+    config_get as_num global local_as "65001"
+
+    echo "log syslog all;"
+    echo "router id $r_id;"
+    echo "define MY_AS = $as_num;"
+    
+    echo "protocol kernel { ipv6 { export all; }; }"
+    echo "protocol device {}"
+}
+
+handle_peer() {
+    local section="$1"
+    local addr remote_as iface imp exp
+    
+    config_get addr "$section" address
+    config_get remote_as "$section" remote_as
+    config_get iface "$section" interface
+    config_get imp "$section" import_filter "all"
+    config_get exp "$section" export_filter "all"
+
+    [ -z "$addr" ] || [ -z "$remote_as" ] && return
+
+    echo "protocol bgp $section {"
+    echo "    local as MY_AS;"
+    echo "    neighbor $addr as $remote_as;"
+    [ -n "$iface" ] && echo "    interface \"$iface\";"
+    
+    echo "    ipv6 {"
+    echo "        import $imp;"
+    echo "        export $exp;"
+    echo "    };"
+    echo "}"
+}
+
+generate_conf() {
+    mkdir -p /var/etc
+    write_header > $BIRD_CONF
+    config_load bird
+    config_foreach handle_peer bgp_peer >> $BIRD_CONF
+}
+
+start_service() {
+    generate_conf
+    mkdir -p /var/run
+    procd_open_instance
+    procd_set_param command $BIRD_BIN -f -c $BIRD_CONF -P $BIRD_PID_FILE
+    procd_set_param stdout 1
+    procd_set_param stderr 1
+    procd_set_param respawn
+    procd_close_instance
+}
+
+service_triggers() {
+    procd_add_reload_trigger "bird"
+}
+
+reload_service() {
+    generate_conf
+    procd_send_signal bird
+}
+


### PR DESCRIPTION

Pull Request Submission
Compile tested: No (Architecture-independent shell scripts and UCI configuration) Run tested: Yes.

Arch: x86_64

Model: QEMU VM

Falter Version: Snapshot (Dec 2025)

Tests done: 1. Verified procd triggers: uci commit successfully triggers config regeneration and bird reload. 2. Verified Dynamic ID: Logic successfully pulled the br-lan IP (192.168.42.1) for the router id. 3. Verified Syntax: bird -p -c /var/etc/bird.conf returns no errors. 4. Verified Filters: UCI import_filter and export_filter options correctly map to Bird2 protocol channels.

Description of the changes: This PR introduces the falter-bird-utils package, a dedicated UCI-to-Bird2 translator. It is designed to modernize how Bird2 is handled on Falter nodes by moving away from static files toward a dynamic, UCI-driven approach.

Key Features:

Automated Logic: Uses an init script with procd integration to handle lifecycle and configuration generation.

Hardware Friendly: Writes the generated bird.conf to /var/etc (RAM) to prevent unnecessary flash wear.

Intelligent Discovery: Includes a BusyBox-compliant pipeline to automatically detect the node's primary IPv4 for the BGP router id.

Bird 2.x Syntax: Specifically handles the local as and ipv6 { channel } syntax requirements of modern Bird versions.