### PR TITLE
build: deterministic build order & switch to github.com again

### DIFF
--- a/build/build.sh
+++ b/build/build.sh
@@ -147,8 +147,8 @@ EOF
   sed -i 's#cc -o contrib/lemon#cc -std=gnu17 -o contrib/lemon#g' feeds/luci/modules/luci-base/src/Makefile
 
   export DOWNLOAD_MIRROR="$srcmirror"
-  for p in $(find -L feeds/falter -name Makefile | awk -F/ '{print $(NF - 1)}'); do
-    cmd="make -j8 package/$p/compile $makeargs"
+  for p in $(find -L feeds/falter -name Makefile | awk -F/ '{print $(NF - 1)}' | sort); do
+    cmd="make package/$p/compile $makeargs"
     echo "-- $cmd"
     $cmd
   done


### PR DESCRIPTION
Kompiliert Ja/Nein: snapshot x86_64
Läuft live Ja/Nein: snapshot x86/64 in a VM

Beschreibung deiner Änderungen:

git.openwrt.org is having a hard couple of days again, let's clone from Github for now.

Also: build packages in a fixed order, and don't build dependencies in parallel. This helps during debugging and doesn't make the build significantly slower.