### PR TITLE
luci-app-ffwizard-falter: wireless device autdetect update

### DIFF
--- a/luci/luci-app-ffwizard-falter/luasrc/model/cbi/freifunk/assistent/wireless.lua
+++ b/luci/luci-app-ffwizard-falter/luasrc/model/cbi/freifunk/assistent/wireless.lua
@@ -382,11 +382,11 @@ function getchannel(device)
   local freqlist = iwinfo.freqlist(device)
 
   local r_channel
-  if (freqlist[1].mhz > 2411 and freqlist[1].mhz < 2484) then
+  if (freqlist[#freqlist].mhz > 2411 and freqlist[#freqlist].mhz < 3000) then
     --this is 2.4 Ghz
     r_channel = tonumber(uci:get(community, "wifi_device", "channel")) or 13
   end
-  if (freqlist[1].mhz > 5179 and freqlist[1].mhz < 5701) then
+  if (freqlist[#freqlist].mhz > 5179 and freqlist[#freqlist].mhz < 6000) then
     --this is 5 Ghz
     r_channel = tonumber(uci:get(community, "wifi_device_5", "channel")) or 36
   end


### PR DESCRIPTION
On some wireless devices which run in the 5ghz range, the call to iwinfo $DEV freqlist may also list invalid 2.4ghz frequencies. Instead of checking if the first in the freqlist is in the valid range, check the last in the freqlist.  Also, expand the valid range of freqs for 2.4 and 5ghz to ensure all potential channels are covered.

Kompiliert Nein
Läuft live Ja: ex400 auf falter 1.5.0-snapshot

