### PR TITLE
bird2, bird3: filesize optimization

### DIFF
--- a/packages/bird2-babelpatch/Makefile
+++ b/packages/bird2-babelpatch/Makefile
@@ -57,7 +57,7 @@ This is the 2.0 branch of Bird which integrates support for IPv4 and IPv6
 into a single branch, and also adds support for the Babel routing protocol.
 endef
 
-CONFIGURE_ARGS += --disable-libssh
+CONFIGURE_ARGS += --disable-libssh --with-protocols=babel,bgp,mrt,pipe,static
 
 define Package/bird2/conffiles
 /etc/bird.conf

--- a/packages/bird3-babelpatch/Makefile
+++ b/packages/bird3-babelpatch/Makefile
@@ -51,7 +51,7 @@ configuration syntax.
 This is the 3.0 branch of Bird which is a multithreaded rewrite.
 endef
 
-CONFIGURE_ARGS += --disable-libssh
+CONFIGURE_ARGS += --disable-libssh --with-protocols=babel,bgp,mrt,pipe,static
 TARGET_LDFLAGS += -latomic
 
 define Package/bird3-babelpatch/conffiles


### PR DESCRIPTION
Kompiliert Ja/Nein: mipsel_24kc & x86_64 snapshot
Läuft live Ja/Nein: mt7621 @ lause, x86/64 snapshot in VM

Beschreibung deiner Änderungen:
```
-rw-r--r--. 1 user user 12714539 26. Jan 22:33 tmp/images/lause-core.bin
-rwxr-xr-x    1 root     root       1071076 Jan 14 11:21 /usr/sbin/bird
-rwxr-xr-x    1 root     root         68328 Jan 14 11:21 /usr/sbin/birdc

-rw-r--r--. 1 user user 12649003 26. Jan 22:25 tmp/images/lause-core.bin
-rwxr-xr-x    1 root     root        872884 Jan 26 00:43 /usr/sbin/bird
-rwxr-xr-x    1 root     root         68328 Jan 26 00:43 /usr/sbin/birdc
```

bird3 mipsel_24kc difference:
- 65536 squashfs image (might be 131072 sometimes, it depends on the exact filesystem size and squashfs block boundary size)
- 198192 bird binary

On different architectures, the difference will be bigger or smaller.

cc @PolynomialDivision 