### PR TITLE
tunspace: add passthru mode

### DIFF
--- a/packages/tunspace/Makefile
+++ b/packages/tunspace/Makefile
@@ -6,7 +6,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=tunspace
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_MAINTAINER:=Packet Please <pktpls@systemli.org>
 PKG_LICENSE:=GPL-2.0-only

--- a/packages/tunspace/tunspace.uc
+++ b/packages/tunspace/tunspace.uc
@@ -461,8 +461,13 @@ function uplink_maintenance(cfg) {
     shell_command("ip link add "+netnsifname+" address "+mac+" link "+ifname+" type macvlan mode bridge");
     shell_command("ip link set dev "+netnsifname+" netns "+netns);
     shell_command("ip -n "+netns+" link set up "+netnsifname+"");
+  } else if (mode == "passthru") {
+    // create a macvlan in passthru mode (shares parent MAC):
+    shell_command("ip link add "+netnsifname+" link "+ifname+" type macvlan mode passthru");
+    shell_command("ip link set dev "+netnsifname+" netns "+netns);
+    shell_command("ip -n "+netns+" link set up "+netnsifname+"");
   } else {
-    log(sprintf("uplink mode must be 'bridge' or 'direct', got '%s'", mode));
+    log(sprintf("uplink mode must be 'bridge', 'direct', or 'passthru', got '%s'", mode));
     return false;
   }
 


### PR DESCRIPTION
Compile tested:
- Architecture: mediatek/filogic
- Model: Cudy TR3000 v1
- Falter: OpenWrt 25.12-SNAPSHOT

Run tested:
- Architecture: mediatek/filogic
- Model: Cudy TR3000 v1
- Falter: OpenWrt 25.12-SNAPSHOT
- Tests performed:
  * Configured wireless uplink (wlan_uplink) with SSID
  * Connected to WPA2-PSK encrypted AP
  * DHCP successfully obtained IPv4 address
  * Wireguard tunnels established through the wireless uplink
  * mesh connections working
  * Ping to 8.8.8.8 successful
  * Full mesh network connectivity verified

Description:
Add passthru mode to tunspace for wireless uplink support.

The new 'passthru' mode creates a macvlan interface in passthru mode,
which shares the parent interface's MAC address. This PR is a first step
for wirless uplink configurations in bbb-configs.