### PR TITLE
bgpdisco: improve bgpdisco

### DIFF
--- a/packages/bgpdisco/Makefile
+++ b/packages/bgpdisco/Makefile
@@ -6,7 +6,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=bgpdisco
-PKG_VERSION:=1.1
+PKG_VERSION:=1.2
 PKG_RELEASE:=1
 
 PKG_MAINTAINER:=Simon Polack <spolack+git@mailbox.org>

--- a/packages/bgpdisco/bgpdisco.uc
+++ b/packages/bgpdisco/bgpdisco.uc
@@ -64,15 +64,12 @@ function retrieve_data_from_bird() {
   bird.cmd('mrt dump table "*_bgpdisco" to "' + cfg.bird_mrt_file + '"');
 
 
-  DBG('parse mrt dump');
-  let data = mrtdump.get_routes(cfg.bird_mrt_file);
-
-  DBG('processing routes');
+  DBG('parse mrt dump and process routes');
   let parsed_data = {};
-  for (let route in data) {
+  mrtdump.process_routes(cfg.bird_mrt_file, function(route) {
     if (index(keys(route.attributes), '250') == -1) {
       DBG('skip route due to missing magic attribute: %s', route);
-      continue;
+      return;
     }
     let ip = split(route.prefix, '/')[0];
     for (let darr in json(route.attributes['250'])) {
@@ -82,7 +79,7 @@ function retrieve_data_from_bird() {
         DBG('route is already parsed, do we have stale routes in the network?: %s', route);
       parsed_data[id][ip] = darr;
     }
-  }
+  });
   return parsed_data;
 }
 

--- a/packages/bgpdisco/bgpdisco.uc
+++ b/packages/bgpdisco/bgpdisco.uc
@@ -68,7 +68,7 @@ function retrieve_data_from_bird() {
   DBG('parse mrt dump and process routes');
   let parsed_data = {};
   mrtdump.process_routes(cfg.bird_mrt_file, function(route) {
-    if (index(keys(route.attributes), '250') == -1) {
+    if (!('250' in route.attributes)) {
       DBG('skip route due to missing magic attribute: %s', route);
       return;
     }
@@ -76,7 +76,7 @@ function retrieve_data_from_bird() {
     for (let darr in json(route.attributes['250'])) {
       let id = shift(darr);
       parsed_data[id] ??= {};
-      if (index(keys(parsed_data[id]), ip) != -1)
+      if (ip in parsed_data[id])
         DBG('route is already parsed, do we have stale routes in the network?: %s', route);
       parsed_data[id][ip] = darr;
     }

--- a/packages/bgpdisco/bgpdisco.uc
+++ b/packages/bgpdisco/bgpdisco.uc
@@ -4,6 +4,7 @@ import * as rtnl from 'rtnl';
 import * as uloop from 'uloop';
 import * as fs from 'fs';
 import * as uci from 'uci';
+import * as digest from 'digest';
 import * as mrtdump from 'bgpdisco.mrtdump';
 import * as plugin from 'bgpdisco.plugin';
 import * as birdctl from 'bgpdisco.birdctl';
@@ -16,7 +17,7 @@ let plugins;
 let monitor_interfaces = [];
 
 let cache_neighbors;
-let cache_data;
+let cache_hash = '';
 
 let timer_refresh_remote_data;
 
@@ -98,12 +99,15 @@ function sync_peers() {
 function cb_refresh_remote_data() {
   DBG('cb_refresh_remote_data()');
   let data = retrieve_data_from_bird();
-  if (sprintf('%s', data) == sprintf('%s', cache_data)) {
-    DBG('Received data matches cache - no need to trigger handler plugins');
+  let data_hash = digest.md5(sprintf('%s', data));
+
+  if (data_hash == cache_hash) {
+    DBG('Data hash unchanged - skip handler plugins');
     return;
-  };
-  INFO('Received data differs from cache - trigger handler plugins');
-  cache_data = data;
+  }
+
+  DBG('Data hash changed - triggering handler plugins');
+  cache_hash = data_hash;
   plugins.handle_data(data);
 }
 

--- a/packages/bgpdisco/mrtdump.uc
+++ b/packages/bgpdisco/mrtdump.uc
@@ -2,8 +2,9 @@ import { pack, unpack } from 'struct';
 import { open } from 'fs';
 import { DBG, INFO, WARN, ERR } from 'bgpdisco.logger';
 
-function get_routes(filename) {
-  let _routes = [];
+function process_routes(filename, callback) {
+  let fd = open(filename, 'r');
+  
   function process_prefix(fd, address_size) {
     // Seqno, Prefix Length
     const RIB_ENTRY_SEQPFXL_FMT = '>IB';
@@ -11,7 +12,6 @@ function get_routes(filename) {
     let seqpfxl = fd.read(RIB_ENTRY_SEQPFXL_LEN);
     let _seqpfxl = unpack(RIB_ENTRY_SEQPFXL_FMT, seqpfxl);
 
-    let entry_seqno = _seqpfxl[0];
     let entry_prefix_length = _seqpfxl[1];
 
     const RIB_ENTRY_PREFIX_FMT = '>' + address_size + 'B';
@@ -71,7 +71,7 @@ function get_routes(filename) {
         __route_info.attributes[attr_type] = attr_data;
       }
 
-      push(_routes, __route_info);
+      callback(__route_info);
     }
     return false;
   }
@@ -126,9 +126,15 @@ function get_routes(filename) {
 
   DBG('Reading MRT file %s', filename);
 
-  let fd = open(filename, 'r');
   while (read_header(fd));
+}
 
+function get_routes(filename) {
+  let _routes = [];
+  process_routes(filename, function(route) {
+    push(_routes, route);
+  });
   return _routes;
 }
-export { get_routes };
+
+export { get_routes, process_routes };

--- a/packages/bgpdisco/nameservice.uc
+++ b/packages/bgpdisco/nameservice.uc
@@ -33,9 +33,8 @@ function get_interfaces_with_ip() {
 }
 
 function is_v4(ip) {
-  if (substr(':'))
-    return false;
-  return true;
+  let bytes = iptoarr(ip);
+  return !!(bytes && length(bytes) == 4);
 }
 
 function get_hostname() {
@@ -60,9 +59,9 @@ function get_local_hosts() {
 
     // Strip device from loopback interface first IP
     if (dev == 'lo') {
-      if (!lo_v4 && is_v4)
+      if (!lo_v4 && is_v4(ip))
         lo_v4 = ip;
-      if (!lo_v6 && !is_v4)
+      if (!lo_v6 && !is_v4(ip))
         lo_v6 = ip;
     }
 


### PR DESCRIPTION
This PR impoves various things about bgpdisco.

The original implementation had a peak memory usage of over 12 MB, which is quite a lot especially for low end routers. 

The first commit reduces peak memory consumption with a streaming approach.

Memory:
Original: 12876 KB
Streaming: 2652 KB

Reduction: 79%

Time:

Original: 2.28s
Streaming: 2.25s

The second commit introduces an optimization for comparison of identical data by introducing a hash and comparing the hashed version of the new data against the hash from the previous iteration, saving CPU time in the comparison and memory due to the fact that we do not keep a duplicate of the data from the previous iteration anymore.

The third commit introduces faster comparisons without the need of intermediate key arrays.

The fourth commit improves the is_v4 function and fixes using it. This closes #460

Compile tested and run tested on Falter 1.6 / OpenWRT 25.12

---

I even created a benchmark script for this to test it and also test data integrity. This is the output:

```
==========================================
  MRT Dump Parser Benchmark
==========================================

MRT file: /tmp/mrt_bgpdisco.dump

--- ORIGINAL ---
  Routes: 5127
  Data size: 128589 bytes
  Time: 2.28s
  Memory (RSS): 12876 KB
  Data hash: 0246a6e99d4c4d7adf2a8c2ba77a797bf9ea49dbe4eaf70f7958d73a5f8462b0

--- STREAMING ---
  Routes: 5127
  Data size: 128589 bytes
  Time: 2.25s
  Memory (RSS): 2652 KB
  Data hash: 0246a6e99d4c4d7adf2a8c2ba77a797bf9ea49dbe4eaf70f7958d73a5f8462b0

==========================================
  COMPARISON
==========================================
Data integrity: IDENTICAL - sha256 hashes match
Memory: Original: 12876 KB, Streaming: 2652 KB, Reduction: 79%
Time: Original: 2.28s, Streaming: 2.25s
```