### PR TITLE
bgpdisco: add missing digest package

### DIFF
--- a/packages/bgpdisco/Makefile
+++ b/packages/bgpdisco/Makefile
@@ -6,7 +6,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=bgpdisco
-PKG_VERSION:=1.2
+PKG_VERSION:=1.3
 PKG_RELEASE:=1
 
 PKG_MAINTAINER:=Simon Polack <spolack+git@mailbox.org>
@@ -29,7 +29,8 @@ define Package/bgpdisco
 	$(Package/bgpdisco/default)
 	EXTRA_DEPENDS:= \
 		ucode (>=0), ucode-mod-rtnl (>=0), ucode-mod-debug (>=0), ucode-mod-fs (>=0), \
-		ucode-mod-uloop (>=0), ucode-mod-log (>=0), ucode-mod-struct (>=0)
+		ucode-mod-uloop (>=0), ucode-mod-log (>=0), ucode-mod-struct (>=0), \
+		ucode-mod-digest (>=0)
 endef
 
 define Package/bgpdisco-plugin-nameservice


### PR DESCRIPTION
With https://github.com/freifunk-berlin/falter-packages/commit/f780678a7003180a73189054075c94f113c4d6e1 the digest dependency was introduced, which I failed to add. This fixes this missing dependency.
