### PR TITLE
Preparations for 1.3.1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,9 +29,8 @@ shfmt:
 .PHONY: shfmt
 
 shellcheck:
-	# The excluded cases are supported by Busybox but not POSIX.
-	# TODO update to shellcheck 0.10 for busybox sh support
-	grep -rIzl '^#![[:blank:]]*/bin/sh' ./packages ./luci | xargs shellcheck -S warning -e SC3003,SC3014,SC3018,SC3020,SC3030,SC3039,SC3043,SC3054,SC3060
+	# TODO: investigate the excluded cases, they're from tunneldigger
+	grep -rIzl '^#![[:blank:]]*/bin/sh' ./packages ./luci | xargs shellcheck -s busybox -S warning -e SC3018,SC3030,SC3039,SC3054
 .PHONY: shellcheck
 
 luacheck:

--- a/packages/falter-berlin-autoupdate/Makefile
+++ b/packages/falter-berlin-autoupdate/Makefile
@@ -1,7 +1,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=falter-berlin-autoupdate
-PKG_VERSION:=2022.08.29
+PKG_VERSION:=2026.06.27
 
 PKG_LICENSE:=GPL-3.0-or-later
 PKG_LICENSE_FILES:=LICENSE

--- a/packages/falter-berlin-autoupdate/files/autoupdate.sh
+++ b/packages/falter-berlin-autoupdate/files/autoupdate.sh
@@ -86,7 +86,6 @@ while getopts him:Nntf option; do
         i) OPT_IGNORE_CERTS=1 ;;
         m) MIN_CERTS=$OPTARG ;;
         N) OPT_NOW=1 ;;
-        n) OPT_N=1 ;;
         t) OPT_TESTRUN=1 ;;
         f) OPT_FORCE=1 ;;
         *)
@@ -223,58 +222,10 @@ if semverLT "$FREIFUNK_RELEASE" "$latest_release"; then
         log "Image hash is correct. sha256sum: $hash_sum"
     fi
 
-    # The following emulates sysupgrade's option --ignore-minor-compat-version,
-    # which isn't available until OpenWrt 23.05.
-    # We need it to allow autoupdates for devices that received DSA support
-    # and had their compat_version increased from 1.0 to 1.1.
-    # In this case, we manually set 1.1 in the system config, check the image,
-    # and then do the upgrade.
-    # If anything goes wrong, we try to set compat_version back to 1.0.
-    #
-    # Once we've moved off OpenWrt 21.02 and 22.03, most of this can be removed
-    # and we'll simply use the --ignore-minor-compat-version option.
-
-    sysupargs=""
-    [ -z "$OPT_N" ] || sysupargs="$sysupargs -n"
-
-    compver_up=""
-    compver_cur=""
-    compmsg=""
-    fwtool -i "$PATH_DIR/sysupgrade.json" "$PATH_BIN"
-    json_init
-    json_load_file "$PATH_DIR/sysupgrade.json"
-    json_get_var "compver_up" "compat_version"
-    json_get_var "compmsg" "compat_message"
-    json_cleanup
-    compver_cur="$(uci get system.@system[0].compat_version 2>/dev/null || echo "1.0")"
-    compmsg2="$(echo "$compmsg" | fgrep DSA)"
-
-    if [ "$compver_cur" == "1.0" ] && [ "$compver_up" == "1.1" ] && [ -n "$compmsg2" ]; then
-        log "this is a DSA sysupgrade."
-        uci set system.@system[0].compat_version=$compver_up
-        sysupgrade -T "$PATH_BIN"
-        ret_code=$?
-        if [ $ret_code != 0 ]; then
-            uci set system.@system[0].compat_version=$compver_cur
-            log "sysupgrade -T failed."
-            exit 2
-        else
-            log "sysupgrade -T succeeded."
-        fi
-        if [ -z "$OPT_TESTRUN" ]; then
-            sysupargs="$sysupargs -F"
-        else
-            uci set system.@system[0].compat_version=$compver_cur
-        fi
-    fi
     if [ -z "$OPT_TESTRUN" ]; then
         log "start flashing the image..."
-        echo "running sysupgrade $sysupargs $PATH_BIN"
-        sysupgrade $sysupargs "$PATH_BIN"
-        ret_code=$?
-        if [ $ret_code != 0 ]; then
-            uci set system.@system[0].compat_version=$compver_cur
-        fi
+        echo "running sysupgrade $PATH_BIN"
+        sysupgrade "$PATH_BIN"
     fi
 else
     log "$FREIFUNK_RELEASE is the latest version. Nothing to do. I will recheck tomorrow."

--- a/packages/falter-berlin-tunneldigger/Makefile
+++ b/packages/falter-berlin-tunneldigger/Makefile
@@ -1,7 +1,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=falter-berlin-tunneldigger
-PKG_SOURCE_DATE:=2020-08-10
+PKG_SOURCE_DATE:=2026-06-27
 PKG_RELEASE:=4
 
 PKG_SOURCE_PROTO:=git

--- a/packages/falter-berlin-tunneldigger/files/tunneldigger.init
+++ b/packages/falter-berlin-tunneldigger/files/tunneldigger.init
@@ -62,12 +62,13 @@ missing() {
 handle_td() {
         local cfg="$1"; shift
         # determine if we should start only this instance
-        local sections=("$@")
+        # shellcheck disable=SC2124
+        local sections="$@"
         local argn="$#"
         local skip=0
         if [ $argn -ne 0 ]; then
                 skip=1
-                for section in "${sections[@]}"; do
+                for section in $sections; do
                         if [ "$cfg" == "$section" ]; then
                                 skip=0
                                 break
@@ -161,7 +162,8 @@ start() {
 # to stop all tunneldigger sections.  With arguements, only the listed tunneldigger
 # sections are stopped
 stop() {
-        local sections=("$@")
+        # shellcheck disable=SC2124
+        local sections="$@"
         local argn=$#
         for PIDFILE in `find ${PIDPATH}/ -name "tunneldigger\.*\.pid"`; do
                 PID="$(cat ${PIDFILE})"
@@ -170,7 +172,7 @@ stop() {
                 local skip=0
                 if [ $argn -ne 0 ]; then
                         skip=1
-                        for section in "${sections[@]}"; do
+                        for section in $sections; do
                                 local section_iface
                                 section_iface="$(uci get tunneldigger.${section}.interface)"
                                 if [ $IFACE = $section_iface ]; then


### PR DESCRIPTION
Compile tested: x86_64, powerpc_8548
Run tested: x86/64 VM @ snapshot, mpc85xx/p1010 wdr4900 @ 1.4.0-snapshot

Description of your changes:
- Update `make lint` to use shellcheck's new busybox mode
- Fix erroneous linter-motivated amendments in tunneldigger service file
- Revert autoupdater compat-version hack, we do not want to jump to DSA yet, we can't migrate the config correctly yet

Fixes #511