### PR TITLE
defaults and migration for 1.3.1

### DIFF
--- a/luci/luci-app-ffwizard-falter/luasrc/model/cbi/freifunk/assistent/wireless.lua
+++ b/luci/luci-app-ffwizard-falter/luasrc/model/cbi/freifunk/assistent/wireless.lua
@@ -300,7 +300,7 @@ function main.write(self, section, value)
     dhcpbase.force = "1"
     dhcpbase.ignore = "0"
     uci:section("dhcp", "dhcp", "dhcp", dhcpbase)
-    uci:set_list("dhcp", "dhcp", "dhcp_option", "119,olsr")
+    uci:set_list("dhcp", "dhcp", "dhcp_option", "119,ff")
     uci:set("dhcp", "dhcp", "dhcpv6", "server")
     uci:set("dhcp", "dhcp", "ra", "server")
     -- DHCP CONFIG set start and limit option

--- a/luci/luci-app-ffwizard-falter/luasrc/tools/freifunk/assistent/olsr.lua
+++ b/luci/luci-app-ffwizard-falter/luasrc/tools/freifunk/assistent/olsr.lua
@@ -32,7 +32,7 @@ end
 
 
 function configureOLSRPlugins()
-	local suffix = uci:get_first(community, "community", "suffix") or "olsr"
+	local suffix = uci:get_first(community, "community", "suffix") or "ff"
 	updatePlugin("olsrd_nameservice", "suffix", "."..suffix)
 	updatePluginInConfig("olsrd", "olsrd_dyn_gw", "PingCmd", "ping -c 1 -q -I ffuplink %s")
 	updatePluginInConfig("olsrd", "olsrd_dyn_gw", "PingInterval", "30")

--- a/packages/falter-berlin-migration/uci-defaults/freifunk-berlin-01-migration.sh
+++ b/packages/falter-berlin-migration/uci-defaults/freifunk-berlin-01-migration.sh
@@ -299,6 +299,11 @@ set_ipversion_olsrd6() {
 }
 
 bump_repo() {
+    local apk=$(which apk)
+    if [ $apk = "" ]; then # This system doesn't have opkg
+      return 0
+    fi
+
     # adjust the opkg packagefeed to point to new version
     local FEED_LINE=$(grep "openwrt_falter" /rom/etc/opkg/customfeeds.conf)
     log "adjusting packagefeed to new version feed"

--- a/packages/falter-berlin-migration/uci-defaults/freifunk-berlin-01-migration.sh
+++ b/packages/falter-berlin-migration/uci-defaults/freifunk-berlin-01-migration.sh
@@ -92,7 +92,7 @@ migrate_profiles() {
     COMMUNITY=$(uci show freifunk.community)
     cp /rom/etc/config/freifunk /etc/config
     OLDIFS=$IFS
-    IFS=$(printf '\n')
+    IFS=$'\n'
     for i in $CONTACT $COMMUNITY; do
         key=$(echo "$i" | cut -d = -f 1)
         val=$(echo "$i" | cut -d = -f 2)

--- a/packages/falter-berlin-migration/uci-defaults/freifunk-berlin-01-migration.sh
+++ b/packages/falter-berlin-migration/uci-defaults/freifunk-berlin-01-migration.sh
@@ -1130,6 +1130,19 @@ r1_3_1_domain_suffix() {
     uci commit olsrd6
 }
 
+r1_3_1_hwmode() {
+    handle_radio() {
+      local section=${1}
+      uci -q delete "wireless.$section.hwmode"
+   }
+
+   reset_cb
+   config_load wireless
+   config_foreach handle_radio wifi-device
+
+   uci commit wireless
+}
+
 # TODO: needs testing before release, but there will be much more to migrate
 r1_5_0_remove_unused_stuff() {
     log "remove unused stuff"
@@ -1284,6 +1297,7 @@ migrate() {
 
     if semverLT "${OLD_VERSION}" "1.3.1"; then
 	r1_3_1_domain_suffix
+        r1_3_1_hwmode
 
     if semverLT "${OLD_VERSION}" "1.5.0"; then
         r1_5_0_remove_unused_stuff

--- a/packages/falter-berlin-migration/uci-defaults/freifunk-berlin-01-migration.sh
+++ b/packages/falter-berlin-migration/uci-defaults/freifunk-berlin-01-migration.sh
@@ -1092,6 +1092,44 @@ r1_3_0_autoupdate_url() {
     uci commit autoupdate
 }
 
+r1_3_1_domain_suffix() {
+    # determine the suffix, default to "ff"
+    local community=$(uci -q get freifunk.community.name)
+    local suffix=$(uci -q get "profile_${community}.profile.suffix")
+    if [ "$suffix" = "" ]; then
+      suffix = "ff"
+    fi
+
+    # apply to dhcp config
+    uci del_list dhcp.dhcp.dhcp_option="119,olsr"
+    if [ $? -eq 0 ]; then
+      uci add_list dhcp.dhcp.dhcp_option="119,${suffix}"
+    fi
+    uci set dhcp.@dnsmasq[0].domain=".${suffix}"
+
+    # apply to olsrd config
+    olsrd_suffix() {
+      local section=${1}
+      local config=${2}
+      local library=""
+      config_get library "$section" library
+      if [ "$library" = "olsrd_nameservice" ]; then
+        uci set "$config.$section".suffix=${suffix}
+      fi
+    }
+    reset_cb
+    config_load olsrd
+    config_foreach olsrd_suffix LoadPlugin olsrd
+
+    reset_cb
+    config_load olsrd6
+    config_foreach olsrd_suffix LoadPlugin olsrd6
+
+    uci commit dhcp
+    uci commit olsrd
+    uci commit olsrd6
+}
+
 # TODO: needs testing before release, but there will be much more to migrate
 r1_5_0_remove_unused_stuff() {
     log "remove unused stuff"
@@ -1243,6 +1281,9 @@ migrate() {
         r1_3_0_autoupdate_url
         r1_3_0_update_dns
     fi
+
+    if semverLT "${OLD_VERSION}" "1.3.1"; then
+	r1_3_1_domain_suffix
 
     if semverLT "${OLD_VERSION}" "1.5.0"; then
         r1_5_0_remove_unused_stuff

--- a/packages/falter-common/files/etc/profile.d/10_dynbanner.sh
+++ b/packages/falter-common/files/etc/profile.d/10_dynbanner.sh
@@ -7,7 +7,12 @@
 
 # shellcheck shell=dash
 
-HOSTNAME=$(uci -q get system.@system[0].hostname)".olsr"
+COMMUNITY=$(uci -q get freifunk.community.name)
+SUFFIX=$(uci -q get profile_${COMMUNITY}.profile.suffix)
+if [ 1 -eq $? ]; then
+  SUFFIX="ff"
+fi
+HOSTNAME=$(uci -q get system.@system[0].hostname)".${SUFFIX}"
 IPADDR=$(uci -q get network.dhcp.ipaddr)
 UPTIME=$(uptime | cut -d ',' -f 0 | cut -d ' ' -f 4-) >/dev/null 2>&1
 FREEFL=$(df -h | grep " /overlay" | sed -E -e s/[[:space:]]+/\;/g | cut -d';' -f4) >/dev/null 2>&1

--- a/packages/falter-common/files/etc/uci-defaults/freifunk-berlin-ffwizard3-json
+++ b/packages/falter-common/files/etc/uci-defaults/freifunk-berlin-ffwizard3-json
@@ -13,8 +13,8 @@ if [ ! -f /etc/config/ffwizard ]; then
     exit 1
 fi
 
-# create a ffwizard3-file, if there is none already
-if [ ! -f /etc/ffwizard3.json ]; then
+# create a ffwizard3-file, if there is none already or empty
+if [ ! -s /etc/ffwizard3.json ]; then
     uci2ffwizard >/etc/ffwizard3.json
     exit 0
 fi

--- a/packages/falter-defaults/files/etc/uci-defaults/freifunk-berlin-olsrd-defaults
+++ b/packages/falter-defaults/files/etc/uci-defaults/freifunk-berlin-olsrd-defaults
@@ -23,7 +23,7 @@ uci set olsrd.$PLUGIN.library=olsrd_arprefresh
 # add nameservice plugin
 PLUGIN="$(uci add olsrd LoadPlugin)"
 uci set olsrd.$PLUGIN.library=olsrd_nameservice
-uci set olsrd.$PLUGIN.suffix=.olsr
+uci set olsrd.$PLUGIN.suffix=.ff
 uci set olsrd.$PLUGIN.hosts_file=/tmp/hosts/olsr
 uci set olsrd.$PLUGIN.latlon_file=/var/run/latlon.js
 uci set olsrd.$PLUGIN.services_file=/var/etc/services.olsr


### PR DESCRIPTION
Kompiliert Ja/Nein: not tested
Läuft live Ja/Nein: runtest on a wdr4900

Beschreibung deiner Änderungen:

change defaults and wizard code to use domain suffix .ff instead of .olsr per default.  Override with community profile settings if possible.  migration is included too.

hwmode is deprecated in openwrt, remove it in the migration

fix the uci-defaults file to run uci2ffwizard if the dest file is emtpy

fix the migrate_profiles code.

fixes: #533