### PR TITLE
falter-common: uci2ffwizard fix hostname and bbbdigger issues

### DIFF
--- a/packages/falter-common/files/sbin/uci2ffwizard
+++ b/packages/falter-common/files/sbin/uci2ffwizard
@@ -72,11 +72,15 @@ else
     is_tunneldigger=""
 fi
 
-has_bbbdigger="$(uci_get tunneldigger bbbdigger interface)"
+bbbdigger_enabled="$(uci_get tunneldigger bbbdigger enabled)"
+if [ $bbbdigger_enabled = "1" ]; then
+    has_bbbdigger="$(uci_get tunneldigger bbbdigger interface)"
+else
+    has_bbbdigger=""
+fi
 
 # get hostname
-json_load "$(ubus call system board)"
-json_get_var hostname hostname
+hostname="$(uci_get system @system[-1] hostname)"
 
 #############################
 #                           #


### PR DESCRIPTION
fixes #541
fixes #544

runtested on a WDR4900 running 1.3.0-snapshot

Results: 
* hostname is properly set
* bbbdigger is listed for the mesh tunnel only if bbbdigger is enabled