### PR TITLE
bgpdisco: fix bugs and reduce CPU load

### DIFF
--- a/packages/bgpdisco/Makefile
+++ b/packages/bgpdisco/Makefile
@@ -6,7 +6,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=bgpdisco
-PKG_VERSION:=1.3
+PKG_VERSION:=1.4
 PKG_RELEASE:=1
 
 PKG_MAINTAINER:=Simon Polack <spolack+git@mailbox.org>

--- a/packages/bgpdisco/Makefile
+++ b/packages/bgpdisco/Makefile
@@ -30,7 +30,7 @@ define Package/bgpdisco
 	EXTRA_DEPENDS:= \
 		ucode (>=0), ucode-mod-rtnl (>=0), ucode-mod-debug (>=0), ucode-mod-fs (>=0), \
 		ucode-mod-uloop (>=0), ucode-mod-log (>=0), ucode-mod-struct (>=0), \
-		ucode-mod-digest (>=0)
+		ucode-mod-digest (>=0), ucode-mod-socket (>=0)
 endef
 
 define Package/bgpdisco-plugin-nameservice

--- a/packages/bgpdisco/bgpdisco.conf
+++ b/packages/bgpdisco/bgpdisco.conf
@@ -2,7 +2,7 @@ package 'bgpdisco'
 
 config general
 	option debug '0'
-	option refresh_remote_data_interval '10'
+	option refresh_remote_data_interval '30'
 	option nice '19'
 
 config bird

--- a/packages/bgpdisco/bgpdisco.uc
+++ b/packages/bgpdisco/bgpdisco.uc
@@ -20,6 +20,7 @@ let cache_neighbors;
 let cache_hash = '';
 
 let timer_refresh_remote_data;
+let timer_sync_debounce;
 
 let cfg = {
     // General
@@ -155,8 +156,11 @@ function cb_nl_newneigh(ev) {
     return;
   }
 
-  DBG('Learned new neighbor - triggering peer syncronization. IP: %s, Dev:', ev.msg.dst, ev.msg.dev);
-  sync_peers();
+  DBG('Learned new neighbor - scheduling peer sync. IP: %s, Dev: %s', ev.msg.dst, ev.msg.dev);
+  if (!timer_sync_debounce)
+    timer_sync_debounce = uloop.timer(500, sync_peers);
+  else
+    timer_sync_debounce.set(500);
 }
 
 function uci_config() {

--- a/packages/bgpdisco/bgpdisco.uc
+++ b/packages/bgpdisco/bgpdisco.uc
@@ -84,10 +84,21 @@ function retrieve_data_from_bird() {
   return parsed_data;
 }
 
+function neighbors_equal(a, b) {
+  if (length(a) != length(b))
+    return false;
+  let sa = sort(map(a, n => n.ip + '/' + n.iface));
+  let sb = sort(map(b, n => n.ip + '/' + n.iface));
+  for (let i = 0; i < length(sa); i++)
+    if (sa[i] != sb[i])
+      return false;
+  return true;
+}
+
 function sync_peers() {
   DBG('sync_peers()');
   let neighbors = bird.get_babel_neighbors();
-  if (sprintf('%s', neighbors) == sprintf('%s', cache_neighbors)) {
+  if (neighbors_equal(neighbors, cache_neighbors)) {
     DBG('No change in babel neighbors - no sync required');
     return;
   }
@@ -128,9 +139,9 @@ function cb_nl_newneigh(ev) {
     return;
   }
 
-  // Ignore other interfaces
-  if (length(cfg.neighbor_sync_monitor_interfaces) > 0) {
-    if (!(ev.msg.dev in cfg.neighbor_sync_monitor_interfaces))
+  // Ignore interfaces not managed by babel
+  if (length(monitor_interfaces) > 0) {
+    if (!(ev.msg.dev in monitor_interfaces))
       return;
   }
 

--- a/packages/bgpdisco/birdctl.uc
+++ b/packages/bgpdisco/birdctl.uc
@@ -1,58 +1,124 @@
-import {popen} from 'fs';
+import * as socket from 'socket';
 import { DBG, INFO, WARN, ERR } from 'bgpdisco.logger';
 
-let sock_bctl_path = '/var/run/bird.ctl';
-const BIRDC_PATH = '/usr/sbin/birdc';
 const RE_BABEL_NEIGHBORS = regexp('(fe80\\S*)\\s*(\\S*)', 'g');
 const RE_BABEL_INTERFACES = regexp('(\\S*)\\s*(Up|Down)', 'g');
 
-function cmd(cmd) {
-  DBG('cmd()');
-  let escaped_command = replace(cmd,'"','\\\"');
+let sock_bctl_path = '/var/run/bird.ctl';
+let _sock = null;
+let _buf = '';
 
-  let cmd_string = sprintf('%s -s %s %s', BIRDC_PATH, sock_bctl_path, escaped_command);
-  DBG('Popen: %s', cmd_string);
-  let p = popen(cmd_string);
-  let response = p.read('all');
-  DBG('Output: %s', response);
-  p.close();
+function _readline() {
+  while (true) {
+    let nl = index(_buf, '\n');
+    if (nl >= 0) {
+      let line = substr(_buf, 0, nl);
+      _buf = substr(_buf, nl + 1);
+      return replace(line, '\r', '');
+    }
+    let chunk = _sock.recv(4096);
+    if (!chunk) {
+      ERR('Bird socket read error: %s', _sock.error());
+      return null;
+    }
+    _buf += chunk;
+  }
+}
 
+// Read one full bird protocol response.
+// Bird responses: "NNNN-text" for continuation lines, "NNNN text" for the final line.
+// Returns the response body with status-code prefixes stripped, or null on error.
+function _read_response() {
+  let lines = [];
+  while (true) {
+    let line = _readline();
+    if (line == null)
+      return null;
+    let text = replace(line, /^\d{4}[-+ ]/, '');
+    if (text != '')
+      push(lines, text);
+    if (match(line, /^\d{4} /))
+      break;
+  }
+  return join('\n', lines);
+}
+
+function _disconnect() {
+  if (_sock) {
+    _sock.close();
+    _sock = null;
+    _buf = '';
+  }
+}
+
+function _connect() {
+  _disconnect();
+  DBG('Connecting to bird control socket: %s', sock_bctl_path);
+  let s = socket.create(socket.AF_UNIX, socket.SOCK_STREAM, 0);
+  if (!s) {
+    ERR('Failed to create socket');
+    return false;
+  }
+  if (!s.connect({ path: sock_bctl_path })) {
+    ERR('Failed to connect to bird control socket %s: %s', sock_bctl_path, s.error());
+    s.close();
+    return false;
+  }
+  _sock = s;
+  _buf = '';
+  _read_response(); // consume greeting line
+  INFO('Connected to bird control socket');
+  return true;
+}
+
+function cmd(command) {
+  DBG('cmd(%s)', command);
+  if (!_sock && !_connect())
+    return '';
+  if (_sock.send(command + '\n') == null) {
+    WARN('Bird socket write failed, reconnecting');
+    if (!_connect())
+      return '';
+    _sock.send(command + '\n');
+  }
+  let response = _read_response();
+  if (response == null) {
+    WARN('Bird socket read failed, will reconnect on next command');
+    _disconnect();
+    return '';
+  }
+  DBG('Response: %s', response);
   return response;
 }
 
 function get_babel_interfaces() {
   DBG('get_babel_interfaces()');
   let response = cmd('show babel interfaces');
-  let matches = match(response, RE_BABEL_INTERFACES); // returns [[iface0, Up], [iface1.., Down]]
+  let matches = match(response, RE_BABEL_INTERFACES);
   let result = [];
-  DBG('matches: %J', matches);
-  for (let _m in matches) {
+  for (let _m in matches)
     push(result, _m[1]);
-  }
   return result;
 }
 
 function get_babel_neighbors() {
   DBG('get_babel_neighbors()');
   let response = cmd('show babel neighbors');
-  let matches = match(response, RE_BABEL_NEIGHBORS); // returns [[fe80.., iface], [fe80.., iface]]
+  let matches = match(response, RE_BABEL_NEIGHBORS);
   let result = [];
-  for (let _m in matches) {
+  for (let _m in matches)
     push(result, {ip: _m[1], iface: _m[2]});
-  }
   return result;
 }
 
 function init(bird_ctl) {
   DBG('init()');
-
-  if (bird_ctl) {
+  if (bird_ctl)
     sock_bctl_path = bird_ctl;
-  }
   return {
-    cmd: cmd,
-    get_babel_interfaces: get_babel_interfaces,
-    get_babel_neighbors: get_babel_neighbors
+    cmd,
+    get_babel_interfaces,
+    get_babel_neighbors,
   };
 }
 

--- a/packages/bgpdisco/birdctl.uc
+++ b/packages/bgpdisco/birdctl.uc
@@ -54,14 +54,9 @@ function _disconnect() {
 function _connect() {
   _disconnect();
   DBG('Connecting to bird control socket: %s', sock_bctl_path);
-  let s = socket.create(socket.AF_UNIX, socket.SOCK_STREAM, 0);
+  let s = socket.connect({ path: sock_bctl_path });
   if (!s) {
-    ERR('Failed to create socket');
-    return false;
-  }
-  if (!s.connect({ path: sock_bctl_path })) {
-    ERR('Failed to connect to bird control socket %s: %s', sock_bctl_path, s.error());
-    s.close();
+    ERR('Failed to connect to bird control socket %s: %s', sock_bctl_path, socket.error());
     return false;
   }
   _sock = s;

--- a/packages/bgpdisco/mrtdump.uc
+++ b/packages/bgpdisco/mrtdump.uc
@@ -51,7 +51,7 @@ function process_routes(filename, callback) {
 
         // set len to two bytes if extended attribute length flag (4) is set
         if (attr_flags & 0x01 << 4) {
-          print('  Extended attribute length!', '\n');
+          DBG('Extended attribute length flag set');
           _field_attr_len = 2;
           _field_attr_unpack_str = '>H';
         }
@@ -105,9 +105,8 @@ function process_routes(filename, callback) {
    }
 
 
-    while (process_prefix(fd, address_size)) {
-      //print("Processing Prefix..");
-    }
+    // TABLE_DUMP_V2 contains exactly one prefix per MRT record
+    process_prefix(fd, address_size);
   }
 
 

--- a/packages/bgpdisco/nameservice.uc
+++ b/packages/bgpdisco/nameservice.uc
@@ -37,8 +37,11 @@ function is_v4(ip) {
   return !!(bytes && length(bytes) == 4);
 }
 
+let _hostname_cache = null;
 function get_hostname() {
-  return replace(fs.readfile('/proc/sys/kernel/hostname'), '\n', '');
+  if (_hostname_cache == null)
+    _hostname_cache = replace(fs.readfile('/proc/sys/kernel/hostname'), '\n', '');
+  return _hostname_cache;
 }
 
 

--- a/packages/bgpdisco/nameservice.uc
+++ b/packages/bgpdisco/nameservice.uc
@@ -14,11 +14,15 @@ let cfg = {
 
 let static_entries = [];
 
+let _local_ips_cache = null;
+
 function get_interfaces_with_ip() {
+  if (_local_ips_cache != null)
+    return _local_ips_cache;
+
   let nl_ips = rtnl.request(rtnl.const.RTM_GETADDR,
                rtnl.const.NLM_F_REQUEST|rtnl.const.NLM_F_ROOT|rtnl.const.NLM_F_MATCH,
                {scope: rtnl.const.RT_SCOPE_UNIVERSE});
-
 
   let result = {};
   for (i in nl_ips) {
@@ -29,6 +33,7 @@ function get_interfaces_with_ip() {
 
     result[split(i.address, '/')[0]] = i.dev;
   }
+  _local_ips_cache = result;
   return result;
 }
 
@@ -167,5 +172,10 @@ return {
     uci_config();
     plug.register(plug.TYPE.DATA_PROVIDER, PLUGIN_UID, get_local_hosts);
     plug.register(plug.TYPE.DATA_HANDLER, PLUGIN_UID, write_hostnames);
+    rtnl.listener(function(ev) {
+      DBG('Address change on %s - invalidating local IP cache', ev.msg.dev);
+      _local_ips_cache = null;
+    }, [rtnl.const.RTM_NEWADDR, rtnl.const.RTM_DELADDR],
+       [rtnl.const.RTNLGRP_IPV4_IFADDR, rtnl.const.RTNLGRP_IPV6_IFADDR], {});
   }
 };

--- a/packages/bgpdisco/plugin.uc
+++ b/packages/bgpdisco/plugin.uc
@@ -23,7 +23,7 @@ function provide_data() {
         data[_ip] ??= [];
 
         let darr = [];
-        if(type(res_cb_data == 'array')) {
+        if (type(res_cb_data) == 'array') {
           darr = res_cb_data;
           unshift(res_cb_data, id); // insert id before data elements
         } else {


### PR DESCRIPTION
- Fix type check parenthesis bug in plugin.uc (dead branch since forever)
- Fix interface filter in cb_nl_newneigh using correct monitor_interfaces variable
- Replace fork+exec birdc subprocess with persistent Unix socket connection to bird
- Fix order-sensitive neighbor comparison with sort-based neighbors_equal()
- Cache hostname in nameservice plugin to avoid repeated /proc reads
- Replace raw print() in mrtdump with DBG(), clean up misleading while loop
- Add ucode-mod-socket dependency

