### PR TITLE
falter-defaults: change forwarding in firewall config

### DIFF
--- a/packages/falter-common/files/etc/config/freifunk
+++ b/packages/falter-common/files/etc/config/freifunk
@@ -14,7 +14,7 @@ config 'public' 'community'
 config 'fw_zone' 'zone_freifunk'
 	option 'name' 'freifunk'
 	option 'input' 'REJECT'
-	option 'forward' 'REJECT'
+	option 'forward' 'ACCEPT'
 	option 'output' 'ACCEPT'
 
 config 'fw_rule' 'fficmp'

--- a/packages/falter-defaults/files/etc/uci-defaults/65-falter-firewall
+++ b/packages/falter-defaults/files/etc/uci-defaults/65-falter-firewall
@@ -87,7 +87,7 @@ uci commit firewall
 # add named freifunk zone section
 uci set firewall.zone_freifunk=zone
 uci set firewall.zone_freifunk.input=ACCEPT
-uci set firewall.zone_freifunk.forward=REJECT
+uci set firewall.zone_freifunk.forward=ACCEPT
 uci set firewall.zone_freifunk.name=freifunk
 uci set firewall.zone_freifunk.output=ACCEPT
 uci add_list firewall.zone_freifunk.network=tunl0
@@ -101,10 +101,6 @@ uci set firewall.zone_ffuplink.forward=ACCEPT
 uci set firewall.zone_ffuplink.output=ACCEPT
 uci add_list firewall.zone_ffuplink.network=ffuplink
 uci set firewall.zone_ffuplink.masq=1
-
-FORWARDING="$(uci add firewall forwarding)"
-uci set firewall."$FORWARDING".dest=freifunk
-uci set firewall."$FORWARDING".src=freifunk
 
 RULE="$(uci add firewall rule)"
 uci set firewall."$RULE".proto=icmp


### PR DESCRIPTION
Having an extra forwarding rule from the freifunk zone to the freifunk zone is not needed.  Simply setting the zone's forward config option to "ACCEPT" accomplishes that same thing.
