### PR TITLE
migration: fix updating customfeeds

### DIFF
--- a/packages/falter-berlin-migration/uci-defaults/freifunk-berlin-01-migration.sh
+++ b/packages/falter-berlin-migration/uci-defaults/freifunk-berlin-01-migration.sh
@@ -305,9 +305,9 @@ bump_repo() {
     fi
 
     # adjust the opkg packagefeed to point to new version
-    local FEED_LINE=$(grep "openwrt_falter" /rom/etc/opkg/customfeeds.conf)
+    local FEED_LINE=$(grep "falter" /rom/etc/opkg/customfeeds.conf)
     log "adjusting packagefeed to new version feed"
-    sed -i "s,src\/gz.openwrt_falter.https\?:\/\/firmware\.berlin\.freifunk\.net.*,$FEED_LINE,g" /etc/opkg/customfeeds.conf
+    sed -i "s,src\/gz.*falter.*,$FEED_LINE,g" /etc/opkg/customfeeds.conf
 }
 
 r1_0_0_vpn03_splitconfig() {


### PR DESCRIPTION
previously, the falter feed was called "openwrt_falter" but now it's just "falter".  Additionally, the hostname part of the URL could be something other than firmware.berlin.freifunk.net (such as a private mirror), so don't match on that string anymore.

