### PR TITLE
luci-mod-falter: delete broken links

### DIFF
--- a/luci/luci-mod-falter/luasrc/controller/freifunk/freifunk.lua
+++ b/luci/luci-mod-falter/luasrc/controller/freifunk/freifunk.lua
@@ -44,15 +44,6 @@ function index()
 		assign({"freifunk", "status", "splash"}, {"splash", "publicstatus"}, _("Splash"), 40)
 	end
 
-	page = assign({"freifunk", "olsr"}, {"admin", "status", "olsr"}, _("OLSR"), 30)
-	page.setuser = false
-	page.setgroup = false
-	page.acl_depends = false
-
-	if nixio.fs.access("/etc/config/luci_statistics") then
-		assign({"freifunk", "graph"}, {"admin", "statistics", "graph"}, _("Statistics"), 40)
-	end
-
 	-- backend
 	assign({"mini", "freifunk"}, {"admin", "freifunk"}, _("Freifunk"), 5)
 
@@ -106,7 +97,5 @@ function index()
 	page.title  = _("Swap Physical Ports")
         page.order  = 41
 
-	entry({"freifunk", "map"}, template("freifunk-map/frame"), _("Map"), 50)
-	entry({"freifunk", "map", "content"}, template("freifunk-map/map"), nil, 51)
 	entry({"admin", "freifunk", "profile_error"}, template("freifunk/profile_error"))
 end


### PR DESCRIPTION
The top menu links to OLSR (available at the bottom of the page), Statistics, and the Wifi Map (also at the bottom) have been removed.  No more 404

runtested on a WDR4900 with 1.4.0-snap

This should be cherry-picked into openwrt 23, 24, and 25.

fixes #536 

