### PR TITLE
falter-berlin-migration: fix pre-kathleen date check

### DIFF
--- a/packages/falter-berlin-migration/uci-defaults/freifunk-berlin-01-migration.sh
+++ b/packages/falter-berlin-migration/uci-defaults/freifunk-berlin-01-migration.sh
@@ -54,15 +54,19 @@ fi
 # at least on "very old file" in /etc/config ...
 #
 FOUND_OLD_FILE=false
-# create helper to compare file ctime (1. Sep. 2014)
-touch -d "201409010000" /tmp/timestamp
+# create helper to compare file ctime (1. Sep. 2014), yet make sure it's at
+# least older than the unix epoch plus one day (2. Jan. 1970).
+touch -d "201409010000" /tmp/kathleenepoch
+touch -d "197001020000" /tmp/unixepoch
 for testfile in /etc/config/*; do
-    if [ "${testfile}" -ot /tmp/timestamp ]; then
+    if [ "${testfile}" -ot /tmp/kathleenepoch ] && [ "${testfile}" -nt /etc/unixepoch ]; then
         FOUND_OLD_FILE=true
-        echo "guessing pre-kathleen firmware as of ${testfile}"
+        KEOPCH=$(date -r /tmp/kathleenepoch)
+        log "guessing pre-kathleen firmware since ${testfile} is older than ${KEPOCH}"
     fi
 done
-rm -f /tmp/timestamp
+rm -f /tmp/kathleenepoch
+rm -f /tmp/unixepoch
 
 if [ -n "${OLD_VERSION}" ]; then
     # case 2)


### PR DESCRIPTION
The migration script checks the files in /etc/config for any files with a date older than the kathleen epoch of 1. Sept 2104.  This was working in the past until upstream openwrt added a new uci-defaults file which creates the config file /etc/ubootenv.  Since the uci-default script runs before the system date can be set via /etc/init.d/sysfixtime, the resulting date of the generated /etc/config/ubootenv is 1. Jan 1970 (the unix epoch).  This breaks the kathleen epoch check in the migration script.

This fix now checks that the files are older than the kathleen epoch, just like before.  But now there is an added check to make sure that the file is newer than the unix epoch (plus 1 day).

--

Runtested with a WDR4900 just after firstboot.  The code snippet was put into a test script and ran successfully.

This commit can be cherry-picked into all active development branches