### PR TITLE
falter-berlin-autoupdate: impl url override

### DIFF
--- a/packages/falter-berlin-autoupdate/files/autoupdate.sh
+++ b/packages/falter-berlin-autoupdate/files/autoupdate.sh
@@ -44,6 +44,8 @@ Optional arguments:
     -t: test-run
             this will perform everything like in automatic-mode, except
             that it won't flash the image and won't tidy up afterwards.
+    -u URL: json URL
+            overrides the URL pointing to the autoupdate.json.
     -f: force update
             CAUTION: This will ignore all checks except the certificates
             and checksums!
@@ -77,7 +79,7 @@ MIN_RAM_FREE=1536 # amount of kiB that must be free in RAM after firmware-downlo
 #########################
 #  Commandline parsing
 
-while getopts him:Nntf option; do
+while getopts him:u:Nntf option; do
     case $option in
         h)
             print_help
@@ -88,6 +90,7 @@ while getopts him:Nntf option; do
         N) OPT_NOW=1 ;;
         t) OPT_TESTRUN=1 ;;
         f) OPT_FORCE=1 ;;
+        u) FW_URL=$OPTARG ;;
         *)
             printf "\nUnknown argument! Please use valid arguments only.\n\n"
             print_help
@@ -100,6 +103,12 @@ done
 MIN_CERTS=$(echo "$MIN_CERTS" | sed -e 's|[^0-9]||g')
 if [ -z "$MIN_CERTS" ]; then
     echo "please give numbers only for -m"
+    exit 2
+fi
+
+# sanitise URL-input
+if [ -z "$FW_URL" ]; then
+    echo "you must give an URL when using -u"
     exit 2
 fi
 


### PR DESCRIPTION
Compile tested: Not yet. Hoping on CI.
Run tested: Not yet. Hopefully will get the chance for this this evening.
Description of your changes:

Implement option -u for overriding the autoupdate.json URL from the command line.

Fixes #559