### PR TITLE
luci: fix problems in 24.10

### DIFF
--- a/luci/luci-app-ffwizard-falter/luasrc/model/cbi/freifunk/assistent/generalInfo.lua
+++ b/luci/luci-app-ffwizard-falter/luasrc/model/cbi/freifunk/assistent/generalInfo.lua
@@ -3,7 +3,7 @@ local sys = require "luci.sys"
 local fs = require "nixio.fs"
 local tools = require "luci.tools.freifunk.assistent.tools"
 
-f = SimpleForm("ffwizward", "", "")
+local f = SimpleForm("ffwizward", "", "")
 f.submit = translate("Next")
 f.reset = false
 

--- a/luci/luci-mod-falter/luasrc/controller/freifunk/freifunk.lua
+++ b/luci/luci-mod-falter/luasrc/controller/freifunk/freifunk.lua
@@ -97,5 +97,7 @@ function index()
 	page.title  = _("Swap Physical Ports")
         page.order  = 41
 
+	entry({"admin", "administration"}, alias("admin", "system", "system"), _("Administration"), 10)
+
 	entry({"admin", "freifunk", "profile_error"}, template("freifunk/profile_error"))
 end


### PR DESCRIPTION
These changes are only needed for the 24.10 branch!!!

The change to luci-app-ffwizard-falter makes sure that the fields on generalInfo get rendered.

The change to luci-mod-falter adds the "Administration" link to the bottom right next to "Freifunk" and "OLSR"

runtested on a live system